### PR TITLE
Remove 2018 Markup

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -225,38 +225,38 @@ article.hero section.top a.blue::before {
   border-color: #416f83;
 }
 
-.page-section, article.footer, article.sponsors, article.faq, article.schedule, article.colorwar, article.intro {
+.page-section, article.footer, article.sponsors, article.faq, article.schedule, article.colorwar, article.trails, article.intro {
   position: relative;
   padding: 12rem 0rem;
 }
-.page-section h2, article.footer h2, article.sponsors h2, article.faq h2, article.schedule h2, article.colorwar h2, article.intro h2 {
+.page-section h2, article.footer h2, article.sponsors h2, article.faq h2, article.schedule h2, article.colorwar h2, article.trails h2, article.intro h2 {
   font-size: 2.4rem;
   margin-bottom: 2rem;
 }
-.page-section h3, article.footer h3, article.sponsors h3, article.faq h3, article.schedule h3, article.colorwar h3, article.intro h3 {
+.page-section h3, article.footer h3, article.sponsors h3, article.faq h3, article.schedule h3, article.colorwar h3, article.trails h3, article.intro h3 {
   font-weight: normal;
   opacity: 0.9;
 }
-.page-section h4, article.footer h4, article.sponsors h4, article.faq h4, article.schedule h4, article.colorwar h4, article.intro h4 {
+.page-section h4, article.footer h4, article.sponsors h4, article.faq h4, article.schedule h4, article.colorwar h4, article.trails h4, article.intro h4 {
   font-size: 2rem;
   color: #FFAF3F;
 }
-.page-section h5, article.footer h5, article.sponsors h5, article.faq h5, article.schedule h5, article.colorwar h5, article.intro h5 {
+.page-section h5, article.footer h5, article.sponsors h5, article.faq h5, article.schedule h5, article.colorwar h5, article.trails h5, article.intro h5 {
   font-size: 1.8rem;
   color: #FFAF3F;
 }
-.page-section p, article.footer p, article.sponsors p, article.faq p, article.schedule p, article.colorwar p, article.intro p {
+.page-section p, article.footer p, article.sponsors p, article.faq p, article.schedule p, article.colorwar p, article.trails p, article.intro p {
   margin-top: 4rem;
   opacity: 0.9;
 }
-.page-section .btn-container, article.footer .btn-container, article.sponsors .btn-container, article.faq .btn-container, article.schedule .btn-container, article.colorwar .btn-container, article.intro .btn-container {
+.page-section .btn-container, article.footer .btn-container, article.sponsors .btn-container, article.faq .btn-container, article.schedule .btn-container, article.colorwar .btn-container, article.trails .btn-container, article.intro .btn-container {
   margin-top: 4rem;
 }
-.page-section.dark, article.dark.footer, article.dark.sponsors, article.dark.faq, article.dark.schedule, article.dark.colorwar, article.dark.intro {
+.page-section.dark, article.dark.footer, article.dark.sponsors, article.dark.faq, article.dark.schedule, article.dark.colorwar, article.dark.trails, article.dark.intro {
   background-color: #1A2E33;
   color: white;
 }
-.page-section.medium, article.medium.footer, article.medium.sponsors, article.medium.faq, article.medium.schedule, article.medium.colorwar, article.medium.intro {
+.page-section.medium, article.medium.footer, article.medium.sponsors, article.medium.faq, article.medium.schedule, article.medium.colorwar, article.medium.trails, article.medium.intro {
   background-color: #22363c;
   color: white;
 }
@@ -283,6 +283,21 @@ article.intro img {
   article.intro img {
     margin-top: 8rem;
   }
+}
+
+article.trails .col-content {
+  margin-top: 4rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+@media (max-width: 767.98px) {
+  article.trails .col-content {
+    text-align: center;
+  }
+}
+article.trails .col-content .icon {
+  margin-top: 4rem;
+  margin-bottom: 2rem;
 }
 
 article.colorwar {
@@ -394,9 +409,3 @@ div.separator.dark-sky {
   background-color: #22363c;
   background-image: url("../img/testx2.jpg");
 }
-
-.container {
-  position: relative;
-}
-
-/*# sourceMappingURL=main.css.map */

--- a/css/main.css
+++ b/css/main.css
@@ -1,42 +1,56 @@
 @font-face {
   font-family: Avenir;
-  src: url("../fonts/Avenir/AvenirLTStd-Book.otf") format("opentype"); }
-
+  src: url("../fonts/Avenir/AvenirLTStd-Book.otf") format("opentype");
+}
 @font-face {
   font-family: Aleo;
-  src: url("../fonts/Aleo/Aleo-Regular.otf") format("opentype"); }
-
+  src: url("../fonts/Aleo/Aleo-Regular.otf") format("opentype");
+}
 html {
-  overflow-x: hidden; }
-  @media (max-width: 575.98px) {
-    html {
-      font-size: 55%; } }
-  @media (min-width: 576px) and (max-width: 767.98px) {
-    html {
-      font-size: 58%; } }
-  @media (min-width: 768px) and (max-width: 991.98px) {
-    html {
-      font-size: 60%; } }
-  @media (min-width: 992px) and (max-width: 1199.98px) {
-    html {
-      font-size: 62.5%; } }
-  @media (min-width: 1200px) {
-    html {
-      font-size: 62.5%; } }
+  overflow-x: hidden;
+}
+@media (max-width: 575.98px) {
+  html {
+    font-size: 55%;
+  }
+}
+@media (min-width: 576px) and (max-width: 767.98px) {
+  html {
+    font-size: 58%;
+  }
+}
+@media (min-width: 768px) and (max-width: 991.98px) {
+  html {
+    font-size: 60%;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199.98px) {
+  html {
+    font-size: 62.5%;
+  }
+}
+@media (min-width: 1200px) {
+  html {
+    font-size: 62.5%;
+  }
+}
 
 body {
   font-size: 1.8rem;
   font-family: Avenir;
   line-height: 1.5;
-  overflow-x: hidden !important; }
+  overflow-x: hidden !important;
+}
 
 h1, h2, h3, h4, h5, h6 {
   margin: 0;
   font-family: Aleo;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 h1, h2, h3, h4, h5, h6, p {
-  line-height: 1.5; }
+  line-height: 1.5;
+}
 
 #mlh-trust-badge {
   display: block;
@@ -46,16 +60,19 @@ h1, h2, h3, h4, h5, h6, p {
   left: 4rem;
   top: -0.1rem;
   width: 10%;
-  transition: ease all .2s;
-  z-index: 100; }
+  transition: ease all 0.2s;
+  z-index: 100;
+}
 
 a {
-  color: #FF6F3F; }
-  a:hover {
-    text-decoration: none;
-    color: #FF6F3F;
-    opacity: 1;
-    filter: brightness(140%); }
+  color: #FF6F3F;
+}
+a:hover {
+  text-decoration: none;
+  color: #FF6F3F;
+  opacity: 1;
+  filter: brightness(140%);
+}
 
 img.icon {
   width: 4rem;
@@ -63,7 +80,8 @@ img.icon {
   image-rendering: -o-crisp-edges;
   image-rendering: -webkit-optimize-contrast;
   -ms-interpolation-mode: nearest-neighbor;
-  image-rendering: pixelated; }
+  image-rendering: pixelated;
+}
 
 a.bp-btn {
   color: white;
@@ -71,29 +89,36 @@ a.bp-btn {
   padding: 1.2rem 1.8rem;
   font-family: Aleo;
   font-weight: bold;
-  transition: ease all .2s;
+  transition: ease all 0.2s;
   text-transform: uppercase;
   background-color: purple;
   text-decoration: none;
   border-radius: 2px;
-  border-bottom: 3px solid #4d004d; }
-  a.bp-btn.orange {
-    background-color: #FF6F3F;
-    border-bottom: 3px solid #ff490c; }
-  a.bp-btn.blue {
-    background-color: #528CA5;
-    border-bottom: 3px solid #416f83; }
-  a.bp-btn.brown {
-    background-color: #7F6C5F;
-    border-bottom: 3px solid #625349; }
-  a.bp-btn.lg {
-    padding: 1.2rem 3.6rem; }
-  a.bp-btn:hover {
-    opacity: 1;
-    filter: brightness(140%); }
-  a.bp-btn:active {
-    opacity: 1;
-    filter: brightness(90%); }
+  border-bottom: 3px solid #4d004d;
+}
+a.bp-btn.orange {
+  background-color: #FF6F3F;
+  border-bottom: 3px solid #ff490c;
+}
+a.bp-btn.blue {
+  background-color: #528CA5;
+  border-bottom: 3px solid #416f83;
+}
+a.bp-btn.brown {
+  background-color: #7F6C5F;
+  border-bottom: 3px solid #625349;
+}
+a.bp-btn.lg {
+  padding: 1.2rem 3.6rem;
+}
+a.bp-btn:hover {
+  opacity: 1;
+  filter: brightness(140%);
+}
+a.bp-btn:active {
+  opacity: 1;
+  filter: brightness(90%);
+}
 
 article.mobile-top {
   background-color: #1A2E33;
@@ -101,283 +126,277 @@ article.mobile-top {
   position: relative;
   z-index: 999;
   height: 16rem;
-  transition: ease height .3s; }
-  article.mobile-top .links {
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    justify-content: space-between;
-    align-items: center; }
-  article.mobile-top a {
-    transition: ease all .3s;
-    text-align: center;
-    display: block;
-    opacity: 1;
-    width: 100%; }
-  article.mobile-top.hidden {
-    height: 0;
-    z-index: -10; }
-    article.mobile-top.hidden a {
-      opacity: 0; }
+  transition: ease height 0.3s;
+}
+article.mobile-top .links {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+  align-items: center;
+}
+article.mobile-top a {
+  transition: ease all 0.3s;
+  text-align: center;
+  display: block;
+  opacity: 1;
+  width: 100%;
+}
+article.mobile-top.hidden {
+  height: 0;
+  z-index: -10;
+}
+article.mobile-top.hidden a {
+  opacity: 0;
+}
 
 article.page-body {
-  position: relative; }
+  position: relative;
+}
 
 article.hero {
   padding: 12rem 1.5rem 18rem;
-  margin-bottom: -.2rem;
+  margin-bottom: -0.2rem;
   background-image: url("../img/herov6.jpg");
   background-size: cover;
-  background-position: bottom; }
-  article.hero .content {
-    text-align: center; }
-    article.hero .content h1 {
-      color: #FFAF3F; }
-    article.hero .content p {
-      color: #7F6C5F; }
-    article.hero .content h1, article.hero .content p {
-      margin-bottom: 2rem; }
-    article.hero .content .logo-box {
-      position: relative; }
-      article.hero .content .logo-box img.fire {
-        position: absolute;
-        width: 20rem;
-        z-index: 12;
-        transform: translateX(3.5rem) translateY(-5rem); }
-      article.hero .content .logo-box img.logo {
-        width: 28rem;
-        height: 28rem;
-        margin-bottom: 1rem; }
-  article.hero section.top {
-    position: absolute;
-    top: 0;
-    width: 100%;
-    right: 0;
-    z-index: 10;
-    padding: 2rem;
-    text-align: right; }
-    article.hero section.top a {
-      position: relative;
-      top: -.5rem;
-      margin-left: 1rem; }
-      article.hero section.top a:hover {
-        top: -.2rem; }
-      article.hero section.top a::before {
-        content: '';
-        position: absolute;
-        z-index: 7;
-        left: 10%;
-        top: -2rem;
-        right: 0;
-        border-left: 4px solid #625349;
-        border-right: 4px solid #625349;
-        background-color: transparent;
-        width: 80%;
-        height: 2rem; }
-      article.hero section.top a.orange::before {
-        border-color: #ff490c; }
-      article.hero section.top a.blue::before {
-        border-color: #416f83; }
-
-.page-section, article.intro, article.trails, article.colorwar, article.schedule, article.faq, article.sponsors, article.footer {
+  background-position: bottom;
+}
+article.hero .content {
+  text-align: center;
+}
+article.hero .content h1 {
+  color: #FFAF3F;
+}
+article.hero .content p {
+  color: #7F6C5F;
+}
+article.hero .content h1, article.hero .content p {
+  margin-bottom: 2rem;
+}
+article.hero .content .logo-box {
   position: relative;
-  padding: 12rem 0rem; }
-  .page-section .trail, article.intro .trail, article.trails .trail, article.colorwar .trail, article.schedule .trail, article.faq .trail, article.sponsors .trail, article.footer .trail {
-    position: absolute;
-    z-index: 99;
-    top: -22rem; }
-    .page-section .trail.left, article.intro .trail.left, article.trails .trail.left, article.colorwar .trail.left, article.schedule .trail.left, article.faq .trail.left, article.sponsors .trail.left, article.footer .trail.left {
-      -webkit-transform: rotate(-10deg);
-      transform: rotate(-10deg);
-      right: 50%; }
-      .page-section .trail.left.flipped, article.intro .trail.left.flipped, article.trails .trail.left.flipped, article.colorwar .trail.left.flipped, article.schedule .trail.left.flipped, article.faq .trail.left.flipped, article.sponsors .trail.left.flipped, article.footer .trail.left.flipped {
-        -webkit-transform: scaleX(-1) rotate(-10deg);
-        transform: scaleX(-1) rotate(-10deg); }
-    .page-section .trail.right, article.intro .trail.right, article.trails .trail.right, article.colorwar .trail.right, article.schedule .trail.right, article.faq .trail.right, article.sponsors .trail.right, article.footer .trail.right {
-      -webkit-transform: rotate(-12deg);
-      transform: rotate(-12deg);
-      left: 50%; }
-      .page-section .trail.right.flipped, article.intro .trail.right.flipped, article.trails .trail.right.flipped, article.colorwar .trail.right.flipped, article.schedule .trail.right.flipped, article.faq .trail.right.flipped, article.sponsors .trail.right.flipped, article.footer .trail.right.flipped {
-        -webkit-transform: scaleY(-1) rotate(-12deg);
-        transform: scaleY(-1) rotate(-12deg); }
-  @media (max-width: 767.98px) {
-    .page-section .first.trail, article.intro .first.trail, article.trails .first.trail, article.colorwar .first.trail, article.schedule .first.trail, article.faq .first.trail, article.sponsors .first.trail, article.footer .first.trail {
-      left: 14%; }
-    .page-section .trail, article.intro .trail, article.trails .trail, article.colorwar .trail, article.schedule .trail, article.faq .trail, article.sponsors .trail, article.footer .trail {
-      position: absolute;
-      z-index: 99;
-      top: -22rem; }
-      .page-section .trail.left, article.intro .trail.left, article.trails .trail.left, article.colorwar .trail.left, article.schedule .trail.left, article.faq .trail.left, article.sponsors .trail.left, article.footer .trail.left {
-        -webkit-transform: scaleX(2) scaleY(2) rotate(-20deg);
-        transform: rotate(-20deg) scaleX(2) scaleY(2);
-        right: 30%; }
-        .page-section .trail.left.flipped, article.intro .trail.left.flipped, article.trails .trail.left.flipped, article.colorwar .trail.left.flipped, article.schedule .trail.left.flipped, article.faq .trail.left.flipped, article.sponsors .trail.left.flipped, article.footer .trail.left.flipped {
-          -webkit-transform: scaleX(-2) scaleY(2) rotate(-20deg);
-          transform: scaleX(-2) scaleY(2) rotate(-20deg); }
-      .page-section .trail.right, article.intro .trail.right, article.trails .trail.right, article.colorwar .trail.right, article.schedule .trail.right, article.faq .trail.right, article.sponsors .trail.right, article.footer .trail.right {
-        -webkit-transform: scaleY(-2) scaleX(2) rotate(-22deg);
-        transform: scaleY(-2) scaleX(2) rotate(-22deg);
-        left: 30%; }
-        .page-section .trail.right.flipped, article.intro .trail.right.flipped, article.trails .trail.right.flipped, article.colorwar .trail.right.flipped, article.schedule .trail.right.flipped, article.faq .trail.right.flipped, article.sponsors .trail.right.flipped, article.footer .trail.right.flipped {
-          -webkit-transform: scaleX(2) scaleY(2) rotate(-22deg);
-          transform: rotate(-22deg) scaleX(2) scaleY(2); } }
-  .page-section h2, article.intro h2, article.trails h2, article.colorwar h2, article.schedule h2, article.faq h2, article.sponsors h2, article.footer h2 {
-    font-size: 2.4rem;
-    margin-bottom: 2rem; }
-  .page-section h3, article.intro h3, article.trails h3, article.colorwar h3, article.schedule h3, article.faq h3, article.sponsors h3, article.footer h3 {
-    font-weight: normal;
-    opacity: .9; }
-  .page-section h4, article.intro h4, article.trails h4, article.colorwar h4, article.schedule h4, article.faq h4, article.sponsors h4, article.footer h4 {
-    font-size: 2.0rem;
-    color: #FFAF3F; }
-  .page-section h5, article.intro h5, article.trails h5, article.colorwar h5, article.schedule h5, article.faq h5, article.sponsors h5, article.footer h5 {
-    font-size: 1.8rem;
-    color: #FFAF3F; }
-  .page-section p, article.intro p, article.trails p, article.colorwar p, article.schedule p, article.faq p, article.sponsors p, article.footer p {
-    margin-top: 4rem;
-    opacity: .9; }
-  .page-section .btn-container, article.intro .btn-container, article.trails .btn-container, article.colorwar .btn-container, article.schedule .btn-container, article.faq .btn-container, article.sponsors .btn-container, article.footer .btn-container {
-    margin-top: 4rem; }
-  .page-section.dark, article.dark.intro, article.dark.trails, article.dark.colorwar, article.dark.schedule, article.dark.faq, article.dark.sponsors, article.dark.footer {
-    background-color: #1A2E33;
-    color: white; }
-  .page-section.medium, article.medium.intro, article.medium.trails, article.medium.colorwar, article.medium.schedule, article.medium.faq, article.medium.sponsors, article.medium.footer {
-    background-color: #22363c;
-    color: white; }
+}
+article.hero .content .logo-box img.fire {
+  position: absolute;
+  width: 20rem;
+  z-index: 12;
+  transform: translateX(3.5rem) translateY(-5rem);
+}
+article.hero .content .logo-box img.logo {
+  width: 28rem;
+  height: 28rem;
+  margin-bottom: 1rem;
+}
+article.hero section.top {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  right: 0;
+  z-index: 10;
+  padding: 2rem;
+  text-align: right;
+}
+article.hero section.top a {
+  position: relative;
+  top: -0.5rem;
+  margin-left: 1rem;
+}
+article.hero section.top a:hover {
+  top: -0.2rem;
+}
+article.hero section.top a::before {
+  content: "";
+  position: absolute;
+  z-index: 7;
+  left: 10%;
+  top: -2rem;
+  right: 0;
+  border-left: 4px solid #625349;
+  border-right: 4px solid #625349;
+  background-color: transparent;
+  width: 80%;
+  height: 2rem;
+}
+article.hero section.top a.orange::before {
+  border-color: #ff490c;
+}
+article.hero section.top a.blue::before {
+  border-color: #416f83;
+}
+
+.page-section, article.footer, article.sponsors, article.faq, article.schedule, article.colorwar, article.intro {
+  position: relative;
+  padding: 12rem 0rem;
+}
+.page-section h2, article.footer h2, article.sponsors h2, article.faq h2, article.schedule h2, article.colorwar h2, article.intro h2 {
+  font-size: 2.4rem;
+  margin-bottom: 2rem;
+}
+.page-section h3, article.footer h3, article.sponsors h3, article.faq h3, article.schedule h3, article.colorwar h3, article.intro h3 {
+  font-weight: normal;
+  opacity: 0.9;
+}
+.page-section h4, article.footer h4, article.sponsors h4, article.faq h4, article.schedule h4, article.colorwar h4, article.intro h4 {
+  font-size: 2rem;
+  color: #FFAF3F;
+}
+.page-section h5, article.footer h5, article.sponsors h5, article.faq h5, article.schedule h5, article.colorwar h5, article.intro h5 {
+  font-size: 1.8rem;
+  color: #FFAF3F;
+}
+.page-section p, article.footer p, article.sponsors p, article.faq p, article.schedule p, article.colorwar p, article.intro p {
+  margin-top: 4rem;
+  opacity: 0.9;
+}
+.page-section .btn-container, article.footer .btn-container, article.sponsors .btn-container, article.faq .btn-container, article.schedule .btn-container, article.colorwar .btn-container, article.intro .btn-container {
+  margin-top: 4rem;
+}
+.page-section.dark, article.dark.footer, article.dark.sponsors, article.dark.faq, article.dark.schedule, article.dark.colorwar, article.dark.intro {
+  background-color: #1A2E33;
+  color: white;
+}
+.page-section.medium, article.medium.footer, article.medium.sponsors, article.medium.faq, article.medium.schedule, article.medium.colorwar, article.medium.intro {
+  background-color: #22363c;
+  color: white;
+}
 
 @media (max-width: 767.98px) {
   article.intro {
-    text-align: center; } }
-
+    text-align: center;
+  }
+}
 article.intro .img-container {
   display: flex;
   align-items: center;
-  justify-content: center; }
-
+  justify-content: center;
+}
 article.intro img {
   width: 100%;
   image-rendering: -moz-crisp-edges;
   image-rendering: -o-crisp-edges;
   image-rendering: -webkit-optimize-contrast;
   -ms-interpolation-mode: nearest-neighbor;
-  image-rendering: pixelated; }
-  @media (max-width: 767.98px) {
-    article.intro img {
-      margin-top: 8rem; } }
-
-article.trails .col-content {
-  margin-top: 4rem;
-  padding-left: 2rem;
-  padding-right: 2rem; }
-  @media (max-width: 767.98px) {
-    article.trails .col-content {
-      text-align: center; } }
-  article.trails .col-content .icon {
-    margin-top: 4rem;
-    margin-bottom: 2rem; }
+  image-rendering: pixelated;
+}
+@media (max-width: 767.98px) {
+  article.intro img {
+    margin-top: 8rem;
+  }
+}
 
 article.colorwar {
   background-image: url("../img/colorwarbg.jpg");
   background-size: cover;
   background-position: bottom;
-  padding-bottom: 28rem; }
-  article.colorwar .icon {
-    width: 8rem;
-    margin-bottom: 4rem; }
+  padding-bottom: 28rem;
+}
+article.colorwar .icon {
+  width: 8rem;
+  margin-bottom: 4rem;
+}
 
 article.schedule .trail-hightlight {
   font-weight: bold;
-  color: #FFAF3F; }
-
+  color: #FFAF3F;
+}
 article.schedule .bp-btn {
-  min-width: 20rem; }
-
+  min-width: 20rem;
+}
 article.schedule p {
-  margin-bottom: 4rem; }
-
+  margin-bottom: 4rem;
+}
 article.schedule h4 {
   text-align: center;
   margin-top: 8rem;
-  margin-bottom: 4rem; }
-
+  margin-bottom: 4rem;
+}
 article.schedule .schedule-table {
   margin-top: 4rem;
   text-align: left;
-  width: 100%; }
-  article.schedule .schedule-table tr {
-    border-bottom: 2px solid #394a50; }
-    article.schedule .schedule-table tr.heading {
-      border: none; }
-  article.schedule .schedule-table th, article.schedule .schedule-table td {
-    min-width: 12rem;
-    padding: 1rem; }
-  article.schedule .schedule-table th {
-    color: #CBF2FF;
-    font-weight: bold; }
+  width: 100%;
+}
+article.schedule .schedule-table tr {
+  border-bottom: 2px solid #394a50;
+}
+article.schedule .schedule-table tr.heading {
+  border: none;
+}
+article.schedule .schedule-table th, article.schedule .schedule-table td {
+  min-width: 12rem;
+  padding: 1rem;
+}
+article.schedule .schedule-table th {
+  color: #CBF2FF;
+  font-weight: bold;
+}
 
 article.faq h5 {
-  margin-top: 4rem; }
-
+  margin-top: 4rem;
+}
 article.faq p {
-  margin-top: 2rem; }
+  margin-top: 2rem;
+}
 
 article.sponsors {
-  /* image styling for sponsor logos */ }
-  article.sponsors div.pitch {
-    margin-top: 4rem;
-    margin-bottom: 4rem; }
-  article.sponsors div.logo {
-    padding: 3.6rem 2rem; }
-    article.sponsors div.logo a {
-      display: block;
-      height: 8rem;
-      display: flex;
-      justify-content: center;
-      align-items: center; }
-      article.sponsors div.logo a:hover {
-        filter: none; }
-    article.sponsors div.logo img {
-      max-height: 100%;
-      max-width: 100%; }
-  article.sponsors .sponsors-img {
-    max-width: 100%;
-    display: block; }
+  /* image styling for sponsor logos */
+}
+article.sponsors div.pitch {
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}
+article.sponsors div.logo {
+  padding: 3.6rem 2rem;
+}
+article.sponsors div.logo a {
+  display: block;
+  height: 8rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+article.sponsors div.logo a:hover {
+  filter: none;
+}
+article.sponsors div.logo img {
+  max-height: 100%;
+  max-width: 100%;
+}
+article.sponsors .sponsors-img {
+  max-width: 100%;
+  display: block;
+}
 
 article.footer .social-icons a {
-  transition: ease all .2s;
-  margin-left: 2rem; }
-  article.footer .social-icons a:first-child {
-    margin-left: 0; }
-  article.footer .social-icons a .icon {
-    margin-top: 4rem;
-    margin-bottom: 2rem;
-    width: 4rem; }
-
+  transition: ease all 0.2s;
+  margin-left: 2rem;
+}
+article.footer .social-icons a:first-child {
+  margin-left: 0;
+}
+article.footer .social-icons a .icon {
+  margin-top: 4rem;
+  margin-bottom: 2rem;
+  width: 4rem;
+}
 div.separator {
   height: 16rem;
-  margin-top: -.2rem;
-  margin-bottom: -.2rem;
+  margin-top: -0.2rem;
+  margin-bottom: -0.2rem;
   background-repeat: repeat-x;
-  background-size: cover; }
-  div.separator.light-sky {
-    background-color: #1A2E33;
-    background-image: url("../img/testx.jpg"); }
-  div.separator.dark-sky {
-    background-color: #22363c;
-    background-image: url("../img/testx2.jpg"); }
-
-.trail_visible .trail_path {
-  stroke-dashoffset: 0; }
-
-.trail_path {
-  fill: none;
-  stroke: #CDECF9;
-  stroke-width: 7;
-  vector-effect: non-scaling-stroke;
-  stroke-dasharray: 21.706,14.706,21.706,14.706,21.706,14.706, 21.706,14.706,21.706,14.706,21.706,14.706, 21.706,14.706,21.706,14.706,21.706,14.706, 21.706,14.706,21.706,14.706,21.706,14.706, 21.706,14.706,21.706,14.706,21.706,14.706, 21.706,14.706,21.706,14.706,21.706,14.706, 0,100000;
-  stroke-dashoffset: 655.416;
-  transition: 2s; }
+  background-size: cover;
+}
+div.separator.light-sky {
+  background-color: #1A2E33;
+  background-image: url("../img/testx.jpg");
+}
+div.separator.dark-sky {
+  background-color: #22363c;
+  background-image: url("../img/testx2.jpg");
+}
 
 .container {
-  position: relative; }
+  position: relative;
+}
+
+/*# sourceMappingURL=main.css.map */

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Bitcamp 2018</title>
+    <title>Bitcamp 2019</title>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -13,16 +13,16 @@
 
     <!-- Meta Tags -->
     <meta name="description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time. Whether you’re a seasoned hacker or completely new to the world of hacking, we’ll have something for you. If you're ready for an adventure, we'll see you by the campfire!">
-    <meta property="og:title" content="Bitcamp 2018">
+    <meta property="og:title" content="Bitcamp 2019">
     <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Bitcamp 2018">
+    <meta property="og:site_name" content="Bitcamp 2019">
     <meta property="og:url" content="http://bit.camp/">
     <meta property="og:description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time.">
     <meta property="og:image" content="http://bit.camp/img/facebook-share-link-2018.jpg" />
     <meta property="og:image:url" content="http://bit.camp/img/facebook-share-link-2018.jpg" />
 
     <meta name="twitter:url" content="http://bit.camp/">
-    <meta name="twitter:title" content="Bitcamp 2018" />
+    <meta name="twitter:title" content="Bitcamp 2019" />
     <meta name="twitter:description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time." />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@bitcmp" />
@@ -41,7 +41,7 @@
       "@context": "http://schema.org",
       "@type": "Corporation",
       "name": "Bitcamp",
-      "alternateName": "Bitcamp 2018",
+      "alternateName": "Bitcamp 2019",
       "url": "http://bit.camp",
       "logo": "http://2017.bit.camp/img/bitcamp-logo-badge.png",
       "sameAs": [
@@ -74,7 +74,7 @@
     <article class="page-body">
 
       <a id="mlh-trust-badge" href="https://mlh.io/seasons/na-2018/events?utm_source=na-2018&utm_medium=TrustBadge&utm_campaign=na-2018&utm_content=black" target="_blank">
-        <img src="./img/mlh-trust-badge-bitcamp-dark-brown.svg" alt="Major League Hacking 2017 Hackathon Season" style="width:100%"></a>
+        <img src="./img/mlh-trust-badge-bitcamp-dark-brown.svg" alt="Major League Hacking 2019 Hackathon Season" style="width:100%"></a>
 
       <article class="hero">
         <!-- TODO UNHIDE THE NABAR WHEN COLORWAR.html GOES LIVE -->
@@ -94,7 +94,7 @@
           </div>
           <h1>Mark Your Trail</h1>
           <p>
-            April 6-8, 2018<br>
+            April 12-14, 2019<br>
             Xfinity Center<br>
             University of Maryland
           </p>
@@ -202,7 +202,7 @@
                 <table class="schedule-table">
                     <tr class="heading">
                         <th colspan="3">
-                            <h4>Friday, April 6th</h4>
+                            <h4>Friday, April 12th</h4>
                         </th>
                     </tr>
                     <tr>
@@ -277,7 +277,7 @@ PM</td>
                 </tr>
                 <tr class="heading">
                     <th colspan="3">
-                    <h4>Saturday, April 7th</h4>
+                    <h4>Saturday, April 13th</h4>
                     </th>
                 </tr>
                 <tr>
@@ -422,7 +422,7 @@ PM</td>
                 </tr>
                 <tr class="heading">
                     <th colspan="3">
-                    <h4>Sunday, April 8th</h4>
+                    <h4>Sunday, April 14th</h4>
                     </th>
                 </tr>
                 <tr>
@@ -542,7 +542,7 @@ PM</td>
             <div class="col-md-6">
               <h5>Timing</h5>
               <p>
-                Participants will arrive between 5PM and 8PM on Friday, April 6th, 2018. Our Sponsor Fair will also be at 7PM, where you can spend time going around and check out our different sponsor booths. Hacking starts Friday evening after opening ceremony. Closing ceremony will begin at 1PM on Sunday, April 8th, 2018.
+                Participants will arrive between 5PM and 8PM on Friday, April 12th, 2019. Our Sponsor Fair will also be at 7PM, where you can spend time going around and check out our different sponsor booths. Hacking starts Friday evening after opening ceremony. Closing ceremony will begin at 1PM on Sunday, April 14th, 2019.
               </p>
               <h5>Location</h5>
               <p>
@@ -911,7 +911,7 @@ PM</td>
               </a>
             </div>
             <br>
-            <p>Copyright © 2018 Bitcamp</p>
+            <p>Copyright © 2019 Bitcamp</p>
           </div>
         </div>
       </article>

--- a/index.html
+++ b/index.html
@@ -1,42 +1,55 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <title>Bitcamp 2019</title>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-MRPP8J');</script>
-    <!-- End Google Tag Manager -->
 
-    <!-- Meta Tags -->
-    <meta name="description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time. Whether you’re a seasoned hacker or completely new to the world of hacking, we’ll have something for you. If you're ready for an adventure, we'll see you by the campfire!">
-    <meta property="og:title" content="Bitcamp 2019">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Bitcamp 2019">
-    <meta property="og:url" content="http://bit.camp/">
-    <meta property="og:description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time.">
-    <meta property="og:image" content="http://bit.camp/img/facebook-share-link-2018.jpg" />
-    <meta property="og:image:url" content="http://bit.camp/img/facebook-share-link-2018.jpg" />
+<head>
+  <meta charset="utf-8">
+  <title>Bitcamp 2019</title>
+  <!-- Google Tag Manager -->
+  <script>
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+      j.async = true;
+      j.src =
+        'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-MRPP8J');
+  </script>
+  <!-- End Google Tag Manager -->
 
-    <meta name="twitter:url" content="http://bit.camp/">
-    <meta name="twitter:title" content="Bitcamp 2019" />
-    <meta name="twitter:description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time." />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@bitcmp" />
-    <meta name="twitter:image" content="http://bit.camp/img/twitter-share-link-2018.jpg" />
-    <!-- End Meta Tags -->
+  <!-- Meta Tags -->
+  <meta name="description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time. Whether you’re a seasoned hacker or completely new to the world of hacking, we’ll have something for you. If you're ready for an adventure, we'll see you by the campfire!">
+  <meta property="og:title" content="Bitcamp 2019">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Bitcamp 2019">
+  <meta property="og:url" content="http://bit.camp/">
+  <meta property="og:description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time.">
+  <meta property="og:image" content="http://bit.camp/img/facebook-share-link-2018.jpg" />
+  <meta property="og:image:url" content="http://bit.camp/img/facebook-share-link-2018.jpg" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <link rel="stylesheet" href="./css/main.css">
-    <link rel="shortcut icon" href="favicon.ico">
-    <!-- PRELOAD HERO IMG -->
-    <link rel="preload" href="./img/herov6.jpg" as="image">
+  <meta name="twitter:url" content="http://bit.camp/">
+  <meta name="twitter:title" content="Bitcamp 2019" />
+  <meta name="twitter:description" content="Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time." />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@bitcmp" />
+  <meta name="twitter:image" content="http://bit.camp/img/twitter-share-link-2018.jpg" />
+  <!-- End Meta Tags -->
 
-    <script type="application/ld+json">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+    crossorigin="anonymous">
+  <link rel="stylesheet" href="./css/main.css">
+  <link rel="shortcut icon" href="favicon.ico">
+  <!-- PRELOAD HERO IMG -->
+  <link rel="preload" href="./img/herov6.jpg" as="image">
+
+  <script type="application/ld+json">
     {
       "@context": "http://schema.org",
       "@type": "Corporation",
@@ -52,33 +65,34 @@
         "https://go.snapchat.com/add/bitcamp"
       ]
     }
-    </script>
-  </head>
-  <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MRPP8J"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
+  </script>
+</head>
 
-    <!-- TODO UNHIDE THE MOBILE NAV WHEN COLORWAR.html GOES LIVE -->
-    <article id="mobile-top" class="mobile-top hidden">
-      <div class="links">
-        <a href="https://bitcamp2018.devpost.com/" target="_blank" class="bp-btn blue ">Devpost</a>
-        <a href="https://apply.bit.camp/login" target="_blank" class="bp-btn orange ">Dashboard</a>
-      </div>
-    </article>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MRPP8J" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
-    <!-- PRELOAD hero img for non chrome and non opera -->
-    <img src="./img/herov6.jpg" style="display:none;">
+  <!-- TODO UNHIDE THE MOBILE NAV WHEN COLORWAR.html GOES LIVE -->
+  <article id="mobile-top" class="mobile-top hidden">
+    <div class="links">
+      <a href="https://bitcamp2018.devpost.com/" target="_blank" class="bp-btn blue ">Devpost</a>
+      <a href="https://apply.bit.camp/login" target="_blank" class="bp-btn orange ">Dashboard</a>
+    </div>
+  </article>
 
-    <article class="page-body">
+  <!-- PRELOAD hero img for non chrome and non opera -->
+  <img src="./img/herov6.jpg" style="display:none;">
 
-      <a id="mlh-trust-badge" href="https://mlh.io/seasons/na-2018/events?utm_source=na-2018&utm_medium=TrustBadge&utm_campaign=na-2018&utm_content=black" target="_blank">
-        <img src="./img/mlh-trust-badge-bitcamp-dark-brown.svg" alt="Major League Hacking 2019 Hackathon Season" style="width:100%"></a>
+  <article class="page-body">
 
-      <article class="hero">
-        <!-- TODO UNHIDE THE NABAR WHEN COLORWAR.html GOES LIVE -->
-        <!-- <section class="top">
+    <a id="mlh-trust-badge" href="https://mlh.io/seasons/na-2018/events?utm_source=na-2018&utm_medium=TrustBadge&utm_campaign=na-2018&utm_content=black"
+      target="_blank">
+      <img src="./img/mlh-trust-badge-bitcamp-dark-brown.svg" alt="Major League Hacking 2019 Hackathon Season" style="width:100%"></a>
+
+    <article class="hero">
+      <!-- TODO UNHIDE THE NABAR WHEN COLORWAR.html GOES LIVE -->
+      <!-- <section class="top">
           <div class="links d-md-none">
             <a href="#" id="menu-btn" class="bp-btn brown">Menu</a>
           </div>
@@ -87,110 +101,132 @@
             <a href="https://apply.bit.camp/login" target="_blank" class="bp-btn orange ">Dashboard</a>
           </div>
         </section> -->
-        <div class="content">
-          <div class="logo-box">
-            <img class="fire" src="./img/fire.gif" alt="">
-            <img class="logo" src="./img/logo_no_fire.svg" alt="">
-          </div>
-          <h1>Mark Your Trail</h1>
-          <p>
-            April 12-14, 2019<br>
-            Xfinity Center<br>
-            University of Maryland
-          </p>
-          <a target="_blank" href="https://bitcamp2018.devpost.com/" class="bp-btn orange lg">View Submissions &rarr;</a>
+      <div class="content">
+        <div class="logo-box">
+          <img class="fire" src="./img/fire.gif" alt="">
+          <img class="logo" src="./img/logo_no_fire.svg" alt="">
         </div>
-      </article>
+        <h1>Mark Your Trail</h1>
+        <p>
+          April 12-14, 2019<br>
+          Xfinity Center<br>
+          University of Maryland
+        </p>
+        <a target="_blank" href="https://bitcamp2018.devpost.com/" class="bp-btn orange lg">View Submissions &rarr;</a>
+      </div>
+    </article>
 
-      <article class="intro dark">
-        <div class="container">
-          <div class="row">
-            <div class="col-md-6">
-              <h2>What is Bitcamp?</h2>
-              <p>
-                Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time. Whether you’re a seasoned hacker or completely new to the world of hacking, we’ll have something for you. If you're ready for an adventure, see you by the fire!
-              </p>
-            </div>
-            <div class="col-md-6 img-container">
-              <img src="./img/icons/grid.png" alt="">
-            </div>
+    <article class="intro dark">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-6">
+            <h2>What is Bitcamp?</h2>
+            <p>
+              Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn
+              something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in
+              for an amazing time. Whether you’re a seasoned hacker or completely new to the world of hacking, we’ll
+              have something for you. If you're ready for an adventure, see you by the fire!
+            </p>
           </div>
-        </div>
-      </article>
-
-      <div class="separator dark-sky"></div>
-      <article class="trails medium" id="trails">
-        <div class="container">
-          <div class="text-center">
-            <h2>Explore Our New Trails</h2>
-            <h3>
-              Participate in Bitcamp this year as a hacker, designer, venturer, or scout.
-            </h3>
-          </div>
-          <div class="row">
-            <div class="col-content col-lg-3 col-md-6">
-              <img class="icon" src="img/icons/desktop.png" alt="">
-              <h4>Hacker Trail</h4>
-              <p>
-                The classic hackathon experience! Build anything cool that comes to your mind, and don’t be afraid to try new technologies. The sky is the limit, and we will have plenty of workshops with topics ranging from Web Development to Machine Learning. There will also be mentors around the clock to help you throughout the weekend, as well as many sponsor prizes up for grabs.
-              </p>
-            </div>
-            <div class="col-content col-lg-3 col-md-6">
-              <img class="icon" src="img/icons/eraser.png" alt="">
-              <h4>Design Trail</h4>
-              <p>
-                Through this Trail, you will have the opportunity to submit a portfolio of your design work for the chance to participate in Bitcamp as a designer. You will act as a mentor and contributor to multiple teams at the event, while developing a portfolio of your designs (your Bitfolio) which will be judged at the end of the hackathon by design professionals.
-              </p>
-            </div>
-            <div class="col-content col-lg-3 col-md-6">
-              <img class="icon" src="img/icons/mug.png" alt="">
-              <h4>Venture Trail</h4>
-              <p>
-                The bustling world of entrepreneurship can be hard to navigate, so we want to offer you the opportunity to hear from key players in the startup space: venture capitalists and student entrepreneurs! We will have workshops geared towards taking your hack to the next level and working on a venture as a student and beyond. Participants in this trail will be able to compete for the “Best Potential Startup” prize, judged by veteran entrepreneurs!
-              </p>
-            </div>
-            <div class="col-content col-lg-3 col-md-6">
-              <img class="icon" src="img/icons/cookie.png" alt="">
-              <h4>Scout Trail</h4>
-              <p>
-                Bitcamp is all about exploration and pursuing your passions, regardless of your experience level. We will have special beginner-oriented workshops and sessions to guide first-timers through both the world of coding and hacking, covering essentials such as how to form your own team, make use of mentors, and submit a project. Beginners will also be able to apply their newly developed skills to a project to compete for the “Best Scout Hack” prize.
-              </p>
-            </div>
+          <div class="col-md-6 img-container">
+            <img src="./img/icons/grid.png" alt="">
           </div>
         </div>
-      </article>
+      </div>
+    </article>
 
-      <div class="separator light-sky"></div>
+    <div class="separator dark-sky"></div>
+    <article class="trails medium" id="trails">
+      <div class="container">
+        <div class="text-center">
+          <h2>Explore Our New Trails</h2>
+          <h3>
+            Participate in Bitcamp this year as a hacker, designer, venturer, or scout.
+          </h3>
+        </div>
+        <div class="row">
+          <div class="col-content col-lg-3 col-md-6">
+            <img class="icon" src="img/icons/desktop.png" alt="">
+            <h4>Hacker Trail</h4>
+            <p>
+              The classic hackathon experience! Build anything cool that comes to your mind, and don’t be afraid to try
+              new technologies. The sky is the limit, and we will have plenty of workshops with topics ranging from Web
+              Development to Machine Learning. There will also be mentors around the clock to help you throughout the
+              weekend, as well as many sponsor prizes up for grabs.
+            </p>
+          </div>
+          <div class="col-content col-lg-3 col-md-6">
+            <img class="icon" src="img/icons/eraser.png" alt="">
+            <h4>Design Trail</h4>
+            <p>
+              Through this Trail, you will have the opportunity to submit a portfolio of your design work for the
+              chance to participate in Bitcamp as a designer. You will act as a mentor and contributor to multiple
+              teams at the event, while developing a portfolio of your designs (your Bitfolio) which will be judged at
+              the end of the hackathon by design professionals.
+            </p>
+          </div>
+          <div class="col-content col-lg-3 col-md-6">
+            <img class="icon" src="img/icons/mug.png" alt="">
+            <h4>Venture Trail</h4>
+            <p>
+              The bustling world of entrepreneurship can be hard to navigate, so we want to offer you the opportunity
+              to hear from key players in the startup space: venture capitalists and student entrepreneurs! We will
+              have workshops geared towards taking your hack to the next level and working on a venture as a student
+              and beyond. Participants in this trail will be able to compete for the “Best Potential Startup” prize,
+              judged by veteran entrepreneurs!
+            </p>
+          </div>
+          <div class="col-content col-lg-3 col-md-6">
+            <img class="icon" src="img/icons/cookie.png" alt="">
+            <h4>Scout Trail</h4>
+            <p>
+              Bitcamp is all about exploration and pursuing your passions, regardless of your experience level. We will
+              have special beginner-oriented workshops and sessions to guide first-timers through both the world of
+              coding and hacking, covering essentials such as how to form your own team, make use of mentors, and
+              submit a project. Beginners will also be able to apply their newly developed skills to a project to
+              compete for the “Best Scout Hack” prize.
+            </p>
+          </div>
+        </div>
+      </div>
+    </article>
 
-      <article id="colorwar" class="colorwar dark">
-        <div class="container text-center">
-          <div class="row">
-            <div class="col-md-8 offset-md-2">
-              <img class="icon" src="img/icons/colorwar_logo.png" alt="">
-              <h2>Are You Ready for COLORWAR?</h2>
-              <p>
-                COLORWAR is a rapid-fire live-design competition and one of the highlights of Bitcamp. Compete in our online design challenge for a chance to draw in front of a live audience at Bitcamp for some cool prizes!
-              </p>
-              <br>
-              <div class="btn-container">
-                <a target="_blank" href="https://medium.com/@bitcmp/calling-all-creatives-for-colorwar-708f0b29543d" class="bp-btn orange">Learn More &nbsp;&rarr;</a>
-              </div>
+    <div class="separator light-sky"></div>
+
+    <article id="colorwar" class="colorwar dark">
+      <div class="container text-center">
+        <div class="row">
+          <div class="col-md-8 offset-md-2">
+            <img class="icon" src="img/icons/colorwar_logo.png" alt="">
+            <h2>Are You Ready for COLORWAR?</h2>
+            <p>
+              COLORWAR is a rapid-fire live-design competition and one of the highlights of Bitcamp. Compete in our
+              online design challenge for a chance to draw in front of a live audience at Bitcamp for some cool prizes!
+            </p>
+            <br>
+            <div class="btn-container">
+              <a target="_blank" href="https://medium.com/@bitcmp/calling-all-creatives-for-colorwar-708f0b29543d"
+                class="bp-btn orange">Learn More &nbsp;&rarr;</a>
             </div>
           </div>
         </div>
-      </article>
+      </div>
+    </article>
 
-      <article class="schedule medium" id="schedule">
-        <div class="container text-center">
-          <div class="row">
-            <div class="col-lg-10 offset-lg-1 col-md-12 col-12">
-              <h2>Schedule</h2>
-              <p>
-                For the latest updates, schedules, maps, and more about Bitcamp, download our new mobile applications for iOS and Android.
-              </p>
-              <a href="https://itunes.apple.com/us/app/bitcamp-2018/id1366799522?mt=8" target="_blank" class="bp-btn orange ">Get for iOS</a>
-              <a href="https://play.google.com/store/apps/details?id=com.bitcamp2018" target="_blank"  class="bp-btn orange ">Get for Android</a>
-              <!--
+    <article class="schedule medium" id="schedule">
+      <div class="container text-center">
+        <div class="row">
+          <div class="col-lg-10 offset-lg-1 col-md-12 col-12">
+            <h2>Schedule</h2>
+            <p>
+              For the latest updates, schedules, maps, and more about Bitcamp, download our new mobile applications for
+              iOS and Android.
+            </p>
+            <a href="https://itunes.apple.com/us/app/bitcamp-2018/id1366799522?mt=8" target="_blank" class="bp-btn orange ">Get
+              for iOS</a>
+            <a href="https://play.google.com/store/apps/details?id=com.bitcamp2018" target="_blank" class="bp-btn orange ">Get
+              for Android</a>
+            <!--
               <table class="schedule-table">
                   <tr class="heading">
                       <th colspan="3">
@@ -474,460 +510,557 @@ PM</td>
               </tr>
               </table>
             -->
-            </div>
           </div>
         </div>
-      </article>
+      </div>
+    </article>
 
-      <div class="separator light-sky"></div>
+    <div class="separator light-sky"></div>
 
-      <article class="faq dark" id="faq">
-        <div class="container">
-          <div class="text-center">
-            <h2>FAQ</h2>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <h5>What is Bitcamp?</h5>
-              <p>
-                Bitcamp is a hackathon that values participant experience and mentorship over competitiveness and points. Come to have fun with your friends, learn something new, eat s’mores, and have a generally awesome time. We have all sorts of crazy activities planned for you...come find out the rest!
-              </p>
-              <h5>What’s a hackathon?</h5>
-              <p>
-                A hackathon is a creative marathon all about building cool things. Students are encouraged to come with an idea, form teams, and then build out that idea into a product in 36 hours. We want you to take something you love (sports, art, camping, anything!) and combine it with technology to make something awesome. It's a great time to push the envelope and learn some new skills.
-              </p>
-              <h5>What have past Bitcampers created?</h5>
-              <p>
-                From Augmented Reality Human-Scale Pong to a research paper detailing vulnerabilities in Google’s reCaptcha system, the projects at Bitcamp span across all categories and interests. You can check out all of the amazing submissions at the Bitcamp 2017 <a target="_blank" href="https://bitcamp2017.devpost.com/">Devpost</a>!
-              </p>
-              <!-- <h5>Who can apply?</h5>
+    <article class="faq dark" id="faq">
+      <div class="container">
+        <div class="text-center">
+          <h2>FAQ</h2>
+        </div>
+        <div class="row">
+          <div class="col-md-6">
+            <h5>What is Bitcamp?</h5>
+            <p>
+              Bitcamp is a hackathon that values participant experience and mentorship over competitiveness and points.
+              Come to have fun with your friends, learn something new, eat s’mores, and have a generally awesome time.
+              We have all sorts of crazy activities planned for you...come find out the rest!
+            </p>
+            <h5>What’s a hackathon?</h5>
+            <p>
+              A hackathon is a creative marathon all about building cool things. Students are encouraged to come with
+              an idea, form teams, and then build out that idea into a product in 36 hours. We want you to take
+              something you love (sports, art, camping, anything!) and combine it with technology to make something
+              awesome. It's a great time to push the envelope and learn some new skills.
+            </p>
+            <h5>What have past Bitcampers created?</h5>
+            <p>
+              From Augmented Reality Human-Scale Pong to a research paper detailing vulnerabilities in Google’s
+              reCaptcha system, the projects at Bitcamp span across all categories and interests. You can check out all
+              of the amazing submissions at the Bitcamp 2017 <a target="_blank" href="https://bitcamp2017.devpost.com/">Devpost</a>!
+            </p>
+            <!-- <h5>Who can apply?</h5>
               <p>
                 Anyone over the age of 18 can apply.
                 <br><br>
                 Unfortunately, minors will not be able to register this year. However, as a part of our new Minors Programs, we will be partnering with various high schools to bring five teams of high school students to Bitcamp.
               </p> -->
-              <h5>What if I have no experience or ideas?</h5>
-              <p>
-                Don't be afraid if you don't think you have enough experience, a team, or an idea. Everyone has a first hackathon, and we would love for Bitcamp to be yours! Mentors who are well-versed in a variety of topics will also be there to help you, whether it be finding a team, fleshing out an idea, or just figuring out where to begin.
-              </p>
-              <h5>How else can I get involved?</h5>
-              <p>
-                We'd love to get you on our volunteering or mentoring teams! If you'd like to help, please fill out <a target="_blank" href="https://bitcamp.typeform.com/to/m5K1bI">this form</a>. Also, be sure to follow us on <a target="_blank" href="https://www.facebook.com/bitcmp">Facebook</a> and <a target="_blank" href="https://twitter.com/bitcmp">Twitter</a> for updates!
-              </p>
-              <h5>What is Slack?</h5>
-              <p>
-                Throughout the event, we will be using Slack as the main form of communication. Never used Slack before? <a target="_blank"  href="https://docs.google.com/presentation/d/1rLijx3npVBSLCfxYSGzmBF8Q6B_NQkkPMlmPhUM4BFQ/edit#slide=id.g2f89ed3a1a_0_25">Here's</a> a quick introduction!
-              </p>
-              <h5>What is Devpost?</h5>
-              <p>
-                After the 36 hours, you’ll be submitting your project to DevPost for judging! New to Devpost? <a target="_blank" href="https://docs.google.com/presentation/d/1rLijx3npVBSLCfxYSGzmBF8Q6B_NQkkPMlmPhUM4BFQ/edit#slide=id.g2e3ac65a77_0_35">Here's</a> a quick introduction!
-              </p>
-              <h5>What hardware will be available at Bitcamp?</h5>
-              <p>
-                Arduinos, sensors (ultrasonic, photoresistors, thermisters), inputs (buttons, switches), outputs (LEDs, piezo speakers, 7-segment displays, micro servo motors), passive components (resistors, capacitors, diodes), and wiring.
-              </p>
-            </div>
+            <h5>What if I have no experience or ideas?</h5>
+            <p>
+              Don't be afraid if you don't think you have enough experience, a team, or an idea. Everyone has a first
+              hackathon, and we would love for Bitcamp to be yours! Mentors who are well-versed in a variety of topics
+              will also be there to help you, whether it be finding a team, fleshing out an idea, or just figuring out
+              where to begin.
+            </p>
+            <h5>How else can I get involved?</h5>
+            <p>
+              We'd love to get you on our volunteering or mentoring teams! If you'd like to help, please fill out <a
+                target="_blank" href="https://bitcamp.typeform.com/to/m5K1bI">this form</a>. Also, be sure to follow us
+              on <a target="_blank" href="https://www.facebook.com/bitcmp">Facebook</a> and <a target="_blank" href="https://twitter.com/bitcmp">Twitter</a>
+              for updates!
+            </p>
+            <h5>What is Slack?</h5>
+            <p>
+              Throughout the event, we will be using Slack as the main form of communication. Never used Slack before?
+              <a target="_blank" href="https://docs.google.com/presentation/d/1rLijx3npVBSLCfxYSGzmBF8Q6B_NQkkPMlmPhUM4BFQ/edit#slide=id.g2f89ed3a1a_0_25">Here's</a>
+              a quick introduction!
+            </p>
+            <h5>What is Devpost?</h5>
+            <p>
+              After the 36 hours, you’ll be submitting your project to DevPost for judging! New to Devpost? <a target="_blank"
+                href="https://docs.google.com/presentation/d/1rLijx3npVBSLCfxYSGzmBF8Q6B_NQkkPMlmPhUM4BFQ/edit#slide=id.g2e3ac65a77_0_35">Here's</a>
+              a quick introduction!
+            </p>
+            <h5>What hardware will be available at Bitcamp?</h5>
+            <p>
+              Arduinos, sensors (ultrasonic, photoresistors, thermisters), inputs (buttons, switches), outputs (LEDs,
+              piezo speakers, 7-segment displays, micro servo motors), passive components (resistors, capacitors,
+              diodes), and wiring.
+            </p>
+          </div>
 
-            <div class="col-md-6">
-              <h5>Timing</h5>
-              <p>
-                Participants will arrive between 6PM and 8PM on Friday, April 12th, 2019. Our Sponsor Fair will also be at 7PM, where you can spend time going around and check out our different sponsor booths. Hacking starts Friday evening after opening ceremony. Closing ceremony will begin at 3PM on Sunday, April 14th, 2019. For a better idea of the flow of the event, check out our <a href="https://2018.bit.camp/" target="_blank">schedule</a> from Bitcamp 2018!
-              </p>
-              <h5>Location</h5>
-              <p>
-                We are proud to host Bitcamp at the Xfinity Center on the University of Maryland campus! This expansive sports arena is a unique spot for any event, and we’re excited to be back again!
-              </p>
-              <h5>Travel</h5>
-              <p>
-                We'll have buses covering the hike from many colleges. If there are many registered campers from one specific college, we will try to have a bus for it. We will be reimbursing any individual’s hiking expenses on a case-by-case basis. Please contact travel@bit.camp for more information.
-              </p>
-              <h5>Packing List</h5>
-              <p>
-                Bring yourself, a photo ID, your signed waiver (if applicable), a change of clothes, toiletries, a sleeping bag/blanket, your hacker setup (laptop, charger, headphones, tablet for designers), and maybe an idea or two!
-              </p>
-              <h5>Teams</h5>
-              <p>
-                Projects are submitted by teams to DevPost. You don't need to finalize your team until project submissions are due during the event. You may work individually or in a team of up to four campers. Don’t have a team in mind? No problem! Hacking will kick off with an optional team formation event.
-              </p>
-              <h5>Guidelines</h5>
-              <p>
-                Don't bring any firearms, knives, weapons, drugs, or alcohol. Don't use an old project. Start a new trail instead! Also, please read the <a target="_blank"  href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf">Major League Hacking Code of Conduct</a> and the <a target="_blank" href="./terms-code-waiver.pdf">Bitcamp Terms, Code of Conduct, and Release Waiver</a>. Organizers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensure a safe environment for everybody (TL;DR be nice).
-              </p>
-              <h5>Other questions?</h5>
-              <p>Please send some mail to <a href="mailto:hello@bit.camp">hello@bit.camp</a>!</p>
+          <div class="col-md-6">
+            <h5>Timing</h5>
+            <p>
+              Participants will arrive between 6PM and 8PM on Friday, April 12th, 2019. Our Sponsor Fair will also be
+              at 7PM, where you can spend time going around and check out our different sponsor booths. Hacking starts
+              Friday evening after opening ceremony. Closing ceremony will begin at 3PM on Sunday, April 14th, 2019.
+              For a better idea of the flow of the event, check out our <a href="https://2018.bit.camp/" target="_blank">schedule</a>
+              from Bitcamp 2018!
+            </p>
+            <h5>Location</h5>
+            <p>
+              We are proud to host Bitcamp at the Xfinity Center on the University of Maryland campus! This expansive
+              sports arena is a unique spot for any event, and we’re excited to be back again!
+            </p>
+            <h5>Travel</h5>
+            <p>
+              We'll have buses covering the hike from many colleges. If there are many registered campers from one
+              specific college, we will try to have a bus for it. We will be reimbursing any individual’s hiking
+              expenses on a case-by-case basis. Please contact travel@bit.camp for more information.
+            </p>
+            <h5>Packing List</h5>
+            <p>
+              Bring yourself, a photo ID, your signed waiver (if applicable), a change of clothes, toiletries, a
+              sleeping bag/blanket, your hacker setup (laptop, charger, headphones, tablet for designers), and maybe an
+              idea or two!
+            </p>
+            <h5>Teams</h5>
+            <p>
+              Projects are submitted by teams to DevPost. You don't need to finalize your team until project
+              submissions are due during the event. You may work individually or in a team of up to four campers. Don’t
+              have a team in mind? No problem! Hacking will kick off with an optional team formation event.
+            </p>
+            <h5>Guidelines</h5>
+            <p>
+              Don't bring any firearms, knives, weapons, drugs, or alcohol. Don't use an old project. Start a new trail
+              instead! Also, please read the <a target="_blank" href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf">Major
+                League Hacking Code of Conduct</a> and the <a target="_blank" href="./terms-code-waiver.pdf">Bitcamp
+                Terms, Code of Conduct, and Release Waiver</a>. Organizers will enforce this code throughout the event.
+              We are expecting cooperation from all participants to help ensure a safe environment for everybody (TL;DR
+              be nice).
+            </p>
+            <h5>Other questions?</h5>
+            <p>Please send some mail to <a href="mailto:hello@bit.camp">hello@bit.camp</a>!</p>
           </div>
         </div>
-      </article>
-
-      <div class="separator dark-sky"></div>
-
-
-      <article class="sponsors medium" id="sponsors">
-        <div class="container">
-          <div class="text-center">
-            <h2>Sponsors</h2>
-            <div class="pitch">
-              <h3>Interested in sponsoring us? <br>Send us an email at <a href="mailto:sponsorship@bit.camp">sponsorship@bit.camp</a>!</h3>
-            </div>
-            <!--  corporate -->
-            <div class="row">
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="http://eng.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/eng.svg" title="A. James Clark School of Engineering"></a>
-                </div>
-              </div>
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="https://cmns.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/cmns.svg" title="College of Mathematical and Natural Sciences"></a>
-                </div>
-              </div>
-            </div>
-            <!--  design partner and recruiter+ -->
-            <div class="row">
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="http://www.finra.org/"><img class="sponsors-img" src="img/sponsor_logos/finra.svg" title="FINRA"></a>
-                </div>
-              </div>
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="http://www.credibleinc.com/"><img class="sponsors-img" src="img/sponsor_logos/credible.svg" title="Credible Behavioral Health"></a>
-                </div>
-              </div>
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="https://ark.io/"><img class="sponsors-img" src="img/sponsor_logos/ark.png" title="Ark"></a>
-                </div>
-              </div>
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="https://www.umdsga.com/"><img class="sponsors-img" src="img/sponsor_logos/sga.png" title="SGA"></a>
-                </div>
-              </div>
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="https://www.facebook.com/careers/"><img class="sponsors-img" src="img/sponsor_logos/facebook.svg" title="Facebook"></a>
-                </div>
-              </div>
-              <div class="col-sm-6">
-                <div class="logo">
-                  <a target="_blank" href="https://www.oculus.com/"><img class="sponsors-img" src="img/sponsor_logos/oculus.png" title="Ocuclus"></a>
-                </div>
-              </div>
-            </div>
-            <!-- recruiter -->
-            <div class="row">
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="https://www.concur.com/"><img class="sponsors-img" src="img/sponsor_logos/concur2.png" title="Concur"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="https://campus.capitalone.com/"><img class="sponsors-img" src="img/sponsor_logos/capitalone.png" title="Capital One"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="https://www.sparkpost.com/"><img class="sponsors-img" src="img/sponsor_logos/sparkpost.png" title="SparkPost"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="http://www.jhuapl.edu/"><img class="sponsors-img" src="img/sponsor_logos/jhu.png" title="JHU APL"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="https://www.leidos.com/"><img class="sponsors-img" src="img/sponsor_logos/leidos.png" title="Leidos"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="http://www.fanniemae.com/portal/index.html"><img class="sponsors-img" src="img/sponsor_logos/fanniemae.png" title="Fannie Mae"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="https://careers.microsoft.com/"><img class="sponsors-img" src="img/sponsor_logos/microsoft.svg" title="Microsoft"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="https://www.esri.com/en-us/home"><img class="sponsors-img" src="img/sponsor_logos/esri.png" title="Esri"></a>
-                </div>
-              </div>
-              <div class="col-sm-4">
-                <div class="logo">
-                  <a target="_blank" href="https://www.lockheedmartin.com/us.html"><img class="sponsors-img" src="img/sponsor_logos/lockheed.png" title="Lockheed Martin"></a>
-                </div>
-              </div>
-            </div>
-            <!-- api and startet -->
-            <div class="row">
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.ciphertechsolutions.com/"><img class="sponsors-img" src="img/sponsor_logos/cipher.svg" title="Cipher Tech Solutions"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.boozallen.com/"><img class="sponsors-img" src="img/sponsor_logos/booz.svg" title="Booz Allen Hamilton"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.bloomberg.com/"><img class="sponsors-img" src="img/sponsor_logos/bloomberg.svg" title="Bloomberg"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.mongodb.com/"><img class="sponsors-img" src="img/sponsor_logos/mongodb.png" title="MongoDB"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.visionistinc.com/"><img class="sponsors-img" src="img/sponsor_logos/visionist.png" title="Visionist"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://validatek.com/"><img class="sponsors-img" src="img/sponsor_logos/validatek.png" title="Validatek"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.paypal.com/us/home"><img class="sponsors-img" src="img/sponsor_logos/paypal.png" title="Paypal"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.predictivetechnologies.com/en"><img class="sponsors-img" src="img/sponsor_logos/apt.svg" title="Applied Predictive Technologies"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.appian.com"><img class="sponsors-img" src="img/sponsor_logos/appian.png" title="Appian"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.carlyle.com/"><img class="sponsors-img" src="img/sponsor_logos/carlyle.svg" title="Carlyle Group"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://bsos.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/bsos.png" title="BSOS"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.reisystems.com/"><img class="sponsors-img" src="img/sponsor_logos/rei_white.png" title="REI Systems"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.linode.com"><img class="sponsors-img" src="img/sponsor_logos/linode.svg" title="Linode"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.asymmetrik.com"><img class="sponsors-img" src="img/sponsor_logos/asymmetrik.png" title="Asymmetrik"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.walmartlabs.com/"><img class="sponsors-img" src="img/sponsor_logos/walmart.svg" title="Walmart Labs"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://www.1517fund.com/"><img class="sponsors-img" src="img/sponsor_logos/1517.png" title="1517 Fund"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://ischool.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/ischool.svg" title="iSchool"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.see.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/see.png" title="SEE"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www-math.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/mathematics.png" title="Math Department"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://gladius.io/"><img class="sponsors-img" src="img/sponsor_logos/gladius.png" title="Gladius"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.telephonics.com/seg"><img class="sponsors-img" src="img/sponsor_logos/seg.png" title="Systems Engineering Group, Inc."></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://fiscalnote.com/"><img class="sponsors-img" src="img/sponsor_logos/fiscalnote.png" title="FiscalNote"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.ibm.com/us-en/"><img class="sponsors-img" src="img/sponsor_logos/ibm.svg" title="https://www.ibm.com/us-en/"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.fbi.gov/"><img class="sponsors-img" src="img/sponsor_logos/FBI.png" title="FBI"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.oracle.com/index.html"><img class="sponsors-img" src="img/sponsor_logos/oracle.png" title="Oracle"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://www.sliceitup.net/"><img class="sponsors-img" src="img/sponsor_logos/slice.png" title="Slice"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://dining.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/dining.png" title="UMD Dining Services"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://www.gotechnica.org"><img class="sponsors-img" src="img/sponsor_logos/technica.png" title="Technica"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://twitter.com/umdawc?lang=en"><img class="sponsors-img" src="img/sponsor_logos/awc.svg" title="AWC"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://www.bomcip.com/"><img class="sponsors-img" src="img/sponsor_logos/bomc.png" title="Bookoff McAndrews PLLC"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.rhsmith.umd.edu/centers-excellence/dingman-center-entrepreneurship"><img class="sponsors-img" src="img/sponsor_logos/dingman.png" title="Dingman"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://sticsumd.com/"><img class="sponsors-img" src="img/sponsor_logos/stics.png" title="STICS"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://insomniacookies.com/"><img class="sponsors-img" src="img/sponsor_logos/insomnia.png" title="Insomnia Cookies"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://goavitae.com"><img class="sponsors-img" src="img/sponsor_logos/avitae.png" title="Avitae"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.livityfoods.com/"><img class="sponsors-img" src="img/sponsor_logos/everbar.png" title="Everbar"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://startupshell.org/"><img class="sponsors-img" src="img/sponsor_logos/startupshell.svg" title="Startup Shell"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://mlh.io/"><img class="sponsors-img" src="img/sponsor_logos/mlh.png" title="MLH"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="http://hackp.ac/mlh-stickermule-hackathons"><img class="sponsors-img" src="img/sponsor_logos/stickermule.svg" title="Sticker Mule"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.deflaw.com/"><img class="sponsors-img" src="img/sponsor_logos/drew.svg" title="Drew Eckl Farnham Law"></a>
-                </div>
-              </div>
-              <div class="col-sm-3">
-                <div class="logo">
-                  <a target="_blank" href="https://www.pepsico.com/"><img class="sponsors-img" src="img/sponsor_logos/pepsi.svg" title="PepsiCo"></a>
-                </div>
-              </div>
-            </div>
-        </div>
-      </article>
-
-      <div class="separator light-sky"></div>
-
-
-      <article class="footer dark">
-        <div class="container">
-          <div class="text-center">
-            <h2>Send us mail at <a href="mailto:hello@bit.camp">hello@bit.camp</a> or tweet <a target="_blank" href="https://twitter.com/bitcmp">@bitcmp</a></h2>
-            <div class="social-icons">
-              <a target="_blank" href="https://www.facebook.com/bitcmp">
-                <img class="icon" src="img/social/face.png" alt="">
-              </a>
-              <a target="_blank" href="https://instagram.com/bitcamp">
-                <img class="icon" src="img/social/insta.png" alt="">
-              </a>
-              <a target="_blank" href="https://twitter.com/bitcmp">
-                <img class="icon" src="img/social/twit.png" alt="">
-              </a>
-              <a target="_blank" href="https://go.snapchat.com/add/bitcamp">
-                <img class="icon" src="img/social/snap.png" alt="">
-              </a>
-            </div>
-            <br>
-            <p>Copyright © 2019 Bitcamp</p>
-          </div>
-        </div>
-      </article>
     </article>
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="./js/main.js"></script>
 
-    <script type="text/javascript">
-  /**
-   * inViewport jQuery plugin by Roko C.B.
-   * http://stackoverflow.com/a/26831113/383904
-   * Returns a callback function with an argument holding
-   * the current amount of px an element is visible in viewport
-   * (The min returned value is 0 (element outside of viewport)
-   */
-  ;(function($, win) {
-    $.fn.inViewport = function(cb) {
-       return this.each(function(i,el) {
-         function visPx(){
-           var elH = $(el).outerHeight(),
-               H = $(win).height(),
-               r = el.getBoundingClientRect(), t=r.top, b=r.bottom;
-           return cb.call(el, Math.max(0, t>0? Math.min(elH, H-t) : (b<H?b:H)));
-         }
-         visPx();
-         $(win).on("resize scroll", visPx);
-       });
-    };
-  }(jQuery, window));
+    <div class="separator dark-sky"></div>
 
-      $(document).ready(function() {
-        $(".trail").inViewport(function(px){
-          if(px) $(this).addClass("trail_visible");
-          // console.log("here!");
-        })
-      });
-    </script>
-  </body>
+
+    <article class="sponsors medium" id="sponsors">
+      <div class="container">
+        <div class="text-center">
+          <h2>Sponsors</h2>
+          <div class="pitch">
+            <h3>Interested in sponsoring us? <br>Send us an email at <a href="mailto:sponsorship@bit.camp">sponsorship@bit.camp</a>!</h3>
+          </div>
+          <!--  corporate -->
+          <div class="row">
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="http://eng.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/eng.svg"
+                    title="A. James Clark School of Engineering"></a>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="https://cmns.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/cmns.svg"
+                    title="College of Mathematical and Natural Sciences"></a>
+              </div>
+            </div>
+          </div>
+          <!--  design partner and recruiter+ -->
+          <div class="row">
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="http://www.finra.org/"><img class="sponsors-img" src="img/sponsor_logos/finra.svg"
+                    title="FINRA"></a>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="http://www.credibleinc.com/"><img class="sponsors-img" src="img/sponsor_logos/credible.svg"
+                    title="Credible Behavioral Health"></a>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="https://ark.io/"><img class="sponsors-img" src="img/sponsor_logos/ark.png"
+                    title="Ark"></a>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="https://www.umdsga.com/"><img class="sponsors-img" src="img/sponsor_logos/sga.png"
+                    title="SGA"></a>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="https://www.facebook.com/careers/"><img class="sponsors-img" src="img/sponsor_logos/facebook.svg"
+                    title="Facebook"></a>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="logo">
+                <a target="_blank" href="https://www.oculus.com/"><img class="sponsors-img" src="img/sponsor_logos/oculus.png"
+                    title="Ocuclus"></a>
+              </div>
+            </div>
+          </div>
+          <!-- recruiter -->
+          <div class="row">
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="https://www.concur.com/"><img class="sponsors-img" src="img/sponsor_logos/concur2.png"
+                    title="Concur"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="https://campus.capitalone.com/"><img class="sponsors-img" src="img/sponsor_logos/capitalone.png"
+                    title="Capital One"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="https://www.sparkpost.com/"><img class="sponsors-img" src="img/sponsor_logos/sparkpost.png"
+                    title="SparkPost"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="http://www.jhuapl.edu/"><img class="sponsors-img" src="img/sponsor_logos/jhu.png"
+                    title="JHU APL"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="https://www.leidos.com/"><img class="sponsors-img" src="img/sponsor_logos/leidos.png"
+                    title="Leidos"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="http://www.fanniemae.com/portal/index.html"><img class="sponsors-img" src="img/sponsor_logos/fanniemae.png"
+                    title="Fannie Mae"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="https://careers.microsoft.com/"><img class="sponsors-img" src="img/sponsor_logos/microsoft.svg"
+                    title="Microsoft"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="https://www.esri.com/en-us/home"><img class="sponsors-img" src="img/sponsor_logos/esri.png"
+                    title="Esri"></a>
+              </div>
+            </div>
+            <div class="col-sm-4">
+              <div class="logo">
+                <a target="_blank" href="https://www.lockheedmartin.com/us.html"><img class="sponsors-img" src="img/sponsor_logos/lockheed.png"
+                    title="Lockheed Martin"></a>
+              </div>
+            </div>
+          </div>
+          <!-- api and startet -->
+          <div class="row">
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.ciphertechsolutions.com/"><img class="sponsors-img" src="img/sponsor_logos/cipher.svg"
+                    title="Cipher Tech Solutions"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.boozallen.com/"><img class="sponsors-img" src="img/sponsor_logos/booz.svg"
+                    title="Booz Allen Hamilton"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.bloomberg.com/"><img class="sponsors-img" src="img/sponsor_logos/bloomberg.svg"
+                    title="Bloomberg"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.mongodb.com/"><img class="sponsors-img" src="img/sponsor_logos/mongodb.png"
+                    title="MongoDB"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.visionistinc.com/"><img class="sponsors-img" src="img/sponsor_logos/visionist.png"
+                    title="Visionist"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://validatek.com/"><img class="sponsors-img" src="img/sponsor_logos/validatek.png"
+                    title="Validatek"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.paypal.com/us/home"><img class="sponsors-img" src="img/sponsor_logos/paypal.png"
+                    title="Paypal"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.predictivetechnologies.com/en"><img class="sponsors-img" src="img/sponsor_logos/apt.svg"
+                    title="Applied Predictive Technologies"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.appian.com"><img class="sponsors-img" src="img/sponsor_logos/appian.png"
+                    title="Appian"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.carlyle.com/"><img class="sponsors-img" src="img/sponsor_logos/carlyle.svg"
+                    title="Carlyle Group"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://bsos.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/bsos.png"
+                    title="BSOS"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.reisystems.com/"><img class="sponsors-img" src="img/sponsor_logos/rei_white.png"
+                    title="REI Systems"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.linode.com"><img class="sponsors-img" src="img/sponsor_logos/linode.svg"
+                    title="Linode"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.asymmetrik.com"><img class="sponsors-img" src="img/sponsor_logos/asymmetrik.png"
+                    title="Asymmetrik"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.walmartlabs.com/"><img class="sponsors-img" src="img/sponsor_logos/walmart.svg"
+                    title="Walmart Labs"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://www.1517fund.com/"><img class="sponsors-img" src="img/sponsor_logos/1517.png"
+                    title="1517 Fund"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://ischool.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/ischool.svg"
+                    title="iSchool"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.see.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/see.png"
+                    title="SEE"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www-math.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/mathematics.png"
+                    title="Math Department"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://gladius.io/"><img class="sponsors-img" src="img/sponsor_logos/gladius.png"
+                    title="Gladius"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.telephonics.com/seg"><img class="sponsors-img" src="img/sponsor_logos/seg.png"
+                    title="Systems Engineering Group, Inc."></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://fiscalnote.com/"><img class="sponsors-img" src="img/sponsor_logos/fiscalnote.png"
+                    title="FiscalNote"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.ibm.com/us-en/"><img class="sponsors-img" src="img/sponsor_logos/ibm.svg"
+                    title="https://www.ibm.com/us-en/"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.fbi.gov/"><img class="sponsors-img" src="img/sponsor_logos/FBI.png"
+                    title="FBI"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.oracle.com/index.html"><img class="sponsors-img" src="img/sponsor_logos/oracle.png"
+                    title="Oracle"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://www.sliceitup.net/"><img class="sponsors-img" src="img/sponsor_logos/slice.png"
+                    title="Slice"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://dining.umd.edu/"><img class="sponsors-img" src="img/sponsor_logos/dining.png"
+                    title="UMD Dining Services"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://www.gotechnica.org"><img class="sponsors-img" src="img/sponsor_logos/technica.png"
+                    title="Technica"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://twitter.com/umdawc?lang=en"><img class="sponsors-img" src="img/sponsor_logos/awc.svg"
+                    title="AWC"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://www.bomcip.com/"><img class="sponsors-img" src="img/sponsor_logos/bomc.png"
+                    title="Bookoff McAndrews PLLC"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.rhsmith.umd.edu/centers-excellence/dingman-center-entrepreneurship"><img
+                    class="sponsors-img" src="img/sponsor_logos/dingman.png" title="Dingman"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://sticsumd.com/"><img class="sponsors-img" src="img/sponsor_logos/stics.png"
+                    title="STICS"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://insomniacookies.com/"><img class="sponsors-img" src="img/sponsor_logos/insomnia.png"
+                    title="Insomnia Cookies"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://goavitae.com"><img class="sponsors-img" src="img/sponsor_logos/avitae.png"
+                    title="Avitae"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.livityfoods.com/"><img class="sponsors-img" src="img/sponsor_logos/everbar.png"
+                    title="Everbar"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://startupshell.org/"><img class="sponsors-img" src="img/sponsor_logos/startupshell.svg"
+                    title="Startup Shell"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://mlh.io/"><img class="sponsors-img" src="img/sponsor_logos/mlh.png"
+                    title="MLH"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="http://hackp.ac/mlh-stickermule-hackathons"><img class="sponsors-img" src="img/sponsor_logos/stickermule.svg"
+                    title="Sticker Mule"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.deflaw.com/"><img class="sponsors-img" src="img/sponsor_logos/drew.svg"
+                    title="Drew Eckl Farnham Law"></a>
+              </div>
+            </div>
+            <div class="col-sm-3">
+              <div class="logo">
+                <a target="_blank" href="https://www.pepsico.com/"><img class="sponsors-img" src="img/sponsor_logos/pepsi.svg"
+                    title="PepsiCo"></a>
+              </div>
+            </div>
+          </div>
+        </div>
+    </article>
+
+    <div class="separator light-sky"></div>
+
+
+    <article class="footer dark">
+      <div class="container">
+        <div class="text-center">
+          <h2>Send us mail at <a href="mailto:hello@bit.camp">hello@bit.camp</a> or tweet <a target="_blank" href="https://twitter.com/bitcmp">@bitcmp</a></h2>
+          <div class="social-icons">
+            <a target="_blank" href="https://www.facebook.com/bitcmp">
+              <img class="icon" src="img/social/face.png" alt="">
+            </a>
+            <a target="_blank" href="https://instagram.com/bitcamp">
+              <img class="icon" src="img/social/insta.png" alt="">
+            </a>
+            <a target="_blank" href="https://twitter.com/bitcmp">
+              <img class="icon" src="img/social/twit.png" alt="">
+            </a>
+            <a target="_blank" href="https://go.snapchat.com/add/bitcamp">
+              <img class="icon" src="img/social/snap.png" alt="">
+            </a>
+          </div>
+          <br>
+          <p>Copyright © 2019 Bitcamp</p>
+        </div>
+      </div>
+    </article>
+  </article>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
+    crossorigin="anonymous"></script>
+  <script src="./js/main.js"></script>
+
+  <script type="text/javascript">
+    /**
+     * inViewport jQuery plugin by Roko C.B.
+     * http://stackoverflow.com/a/26831113/383904
+     * Returns a callback function with an argument holding
+     * the current amount of px an element is visible in viewport
+     * (The min returned value is 0 (element outside of viewport)
+     */
+    ;
+    (function ($, win) {
+      $.fn.inViewport = function (cb) {
+        return this.each(function (i, el) {
+          function visPx() {
+            var elH = $(el).outerHeight(),
+              H = $(win).height(),
+              r = el.getBoundingClientRect(),
+              t = r.top,
+              b = r.bottom;
+            return cb.call(el, Math.max(0, t > 0 ? Math.min(elH, H - t) : (b < H ? b : H)));
+          }
+          visPx();
+          $(win).on("resize scroll", visPx);
+        });
+      };
+    }(jQuery, window));
+
+    $(document).ready(function () {
+      $(".trail").inViewport(function (px) {
+        if (px) $(this).addClass("trail_visible");
+        // console.log("here!");
+      })
+    });
+  </script>
+</body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
             <div class="col-md-6">
               <h2>What is Bitcamp?</h2>
               <p>
-                Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time. Whether you’re a seasoned hacker or completely new to the world of hacking, we’ll have something for you. If you're ready for an adventure, we'll see you by the campfire!
+                Bitcamp is a place for exploration. You will have 36 hours to delve into your curiosities, learn something new, and make something awesome. With world-class mentors and 1,200+ fellow campers, you're in for an amazing time. Whether you’re a seasoned hacker or completely new to the world of hacking, we’ll have something for you. If you're ready for an adventure, see you by the fire!
               </p>
             </div>
             <div class="col-md-6 img-container">
@@ -190,288 +190,290 @@
               </p>
               <a href="https://itunes.apple.com/us/app/bitcamp-2018/id1366799522?mt=8" target="_blank" class="bp-btn orange ">Get for iOS</a>
               <a href="https://play.google.com/store/apps/details?id=com.bitcamp2018" target="_blank"  class="bp-btn orange ">Get for Android</a>
-                <table class="schedule-table">
-                    <tr class="heading">
-                        <th colspan="3">
-                            <h4>Friday, April 12th</h4>
-                        </th>
-                    </tr>
-                    <tr>
-                    <th>TIME</th>
-                    <th>EVENT</th>
-                    <th>LOCATION</th>
-                    </tr><tr>
-                    <td>5:00 PM</td>
-                    <td>Hacker Check-in</td>
-                    <td><a href="./img/check-in-xfinity-gate-a.png">Xfinity Center Gate A</a></td>
-                </tr>
-                <tr>
-                    <td>5:00 PM</td>
-                    <td>Mentor Check-in</td>
-                    <td><a href="./img/check-in-xfinity-gate-a.png">Xfinity Center Gate A</a></td>
-                </tr>
-                <tr>
-                    <td>6:00 PM</td>
-                    <td>UMD Student Check-in</td>
-                    <td><a href="./img/check-in-xfinity-gate-a.png">Xfinity Center Gate A</a></td>
-                </tr>
-                <tr>
-                    <td>6:00 PM</td>
-                    <td>Dinner</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>6:00 PM</td>
-                    <td>Sponsorship Fair</td>
-                    <td>Campgrounds</td>
-                </tr>
-                <tr>
-                    <td>7:30 PM</td>
-                    <td>Opening Ceremony</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>9:00 PM</td>
-                    <td>Hacking Starts</td>
-                    <td>Campgrounds</td>
-                </tr>
-                <tr>
-                    <td>9:00 PM</td>
-                    <td>Dessert</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>9:00 PM</td>
-                    <td>Ark-IoT Blockchain Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>9:45 PM</td>
-                    <td><span class="trail-hightlight">[Scout Trail]</span> Hackathon 101 Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>10:15
+              <!--
+              <table class="schedule-table">
+                  <tr class="heading">
+                      <th colspan="3">
+                          <h4>Friday, April 12th</h4>
+                      </th>
+                  </tr>
+                  <tr>
+                  <th>TIME</th>
+                  <th>EVENT</th>
+                  <th>LOCATION</th>
+                  </tr><tr>
+                  <td>5:00 PM</td>
+                  <td>Hacker Check-in</td>
+                  <td><a href="./img/check-in-xfinity-gate-a.png">Xfinity Center Gate A</a></td>
+              </tr>
+              <tr>
+                  <td>5:00 PM</td>
+                  <td>Mentor Check-in</td>
+                  <td><a href="./img/check-in-xfinity-gate-a.png">Xfinity Center Gate A</a></td>
+              </tr>
+              <tr>
+                  <td>6:00 PM</td>
+                  <td>UMD Student Check-in</td>
+                  <td><a href="./img/check-in-xfinity-gate-a.png">Xfinity Center Gate A</a></td>
+              </tr>
+              <tr>
+                  <td>6:00 PM</td>
+                  <td>Dinner</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>6:00 PM</td>
+                  <td>Sponsorship Fair</td>
+                  <td>Campgrounds</td>
+              </tr>
+              <tr>
+                  <td>7:30 PM</td>
+                  <td>Opening Ceremony</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>9:00 PM</td>
+                  <td>Hacking Starts</td>
+                  <td>Campgrounds</td>
+              </tr>
+              <tr>
+                  <td>9:00 PM</td>
+                  <td>Dessert</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>9:00 PM</td>
+                  <td>Ark-IoT Blockchain Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>9:45 PM</td>
+                  <td><span class="trail-hightlight">[Scout Trail]</span> Hackathon 101 Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>10:15
 PM</td>
-                    <td>Team Formation</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>10:30 PM</td>
-                    <td><span class="trail-hightlight">[Venture Trail]</span> Turn a Hackathon Project into a VC-Funded Product</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>11:30 PM</td>
-                    <td><span class="trail-hightlight">[Design Trail]</span> Intro to Design and Branding Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr class="heading">
-                    <th colspan="3">
-                    <h4>Saturday, April 13th</h4>
-                    </th>
-                </tr>
-                <tr>
-                        <th>TIME</th>
-                        <th>EVENT</th>
-                        <th>LOCATION</th>
-                </tr>
-                <tr>
-                    <td>12:00 AM</td>
-                    <td>Insomnia Cookies</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>1:00 AM</td>
-                    <td>Smash Tournament</td>
-                    <td>Power Peak</td>
-                </tr>
-                <tr>
-                    <td>1:30 AM</td>
-                    <td>Lifesize Hungry Hungry Hippos</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>8:30 AM</td>
-                    <td>Breakfast</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>9:00 AM</td>
-                    <td>Attorney AMA</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>10:00 AM</td>
-                    <td>Amp Up Your Apps With Maps by Esri</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>11:00 AM</td>
-                    <td>Discover the Office 365 Developer Platform by Microsoft</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>11:30 AM</td>
-                    <td><span class="trail-hightlight">[Venture Trail]</span> Entrepeneurship Panel</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>12:00 PM</td>
-                    <td>Open-Source Intelligence Techniques Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>12:30 PM</td>
-                    <td>Lunch</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>1:00 PM</td>
-                    <td><span class="trail-hightlight">[Design Trail]</span> GIFs Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>2:00 PM</td>
-                    <td>Go Bananas Over UX by FINRA</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>2:00 PM</td>
-                    <td>Office Hours with 1517 Fund</td>
-                    <td>1517 Fund Booth</td>
-                </tr>
-                <tr>
-                    <td>2:30 PM</td>
-                    <td>Women in Tech Fireside Chat</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>3:00 PM</td>
-                    <td>Using Technology to Improve Healthcare by Credible Behaviorial Health</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>3:30 PM</td>
-                    <td><span class="trail-hightlight">[Design & Scout Trail]</span> Design Thinking Workshop</td>
-                    <td>Breakout Room</td>
-                </tr>
-                <tr>
-                    <td>4:00 PM</td>
-                    <td>COLORWAR</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>6:00 PM</td>
-                    <td><span class="trail-hightlight">[Venture Trail]</span> Venture Capital and the Art of Funding Your Startup w/ Mike Volpi</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>6:30 PM</td>
-                    <td>Dinner</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>7:00 PM</td>
-                    <td>How 2 Blink LEDs Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>7:30 PM</td>
-                    <td>The Coding Interview Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>8:00 PM</td>
-                    <td>Self-Driving Cars Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>8:00 PM</td>
-                    <td>Ballroom Dancing</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>9:00 PM</td>
-                    <td><span class="trail-hightlight">[Scout Trail]</span> Intro to Web Development Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>10:00 PM</td>
-                    <td>Insomnia Cookies</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>10:00 PM</td>
-                    <td>Intro to Crypto and Blockchain Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr>
-                    <td>11:00 PM</td>
-                    <td>SLAM: Why Robots Don&apos;t Crash Workshop</td>
-                    <td>Cabin</td>
-                </tr>
-                <tr class="heading">
-                    <th colspan="3">
-                    <h4>Sunday, April 14th</h4>
-                    </th>
-                </tr>
-                <tr>
-                        <th>TIME</th>
-                        <th>EVENT</th>
-                        <th>LOCATION</th>
-                </tr>
-                <tr>
-                    <td>12:00 AM</td>
-                    <td>S&apos;mores by APT</td>
-                    <td>Campfire II</td>
-                </tr>
-                <tr>
-                    <td>12:00 AM</td>
-                    <td>MLH Cup Stacking</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>1:00 AM</td>
-                    <td>Late Night Board Game Break</td>
-                    <td>Campfire</td>
-                </tr>
-                <tr>
-                    <td>8:00 AM</td>
-                    <td>Devpost Submission Deadline</td>
-                    <td>Campgrounds</td>
-                </tr>
-                <tr>
-                    <td>8:00 AM</td>
-                    <td>Breakfast</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>9:00 AM</td>
-                    <td>Hacking Ends</td>
-                    <td>Campgrounds</td>
-                </tr>
-                <tr>
-                    <td>9:30 AM</td>
-                    <td>Expo A</td>
-                    <td>Campgrounds</td>
-                </tr>
-                <tr>
-                    <td>11:00 AM</td>
-                    <td>Expo B</td>
-                    <td>Campgrounds</td>
-                </tr>
-                <tr>
-                    <td>12:00 PM</td>
-                    <td>Lunch</td>
-                    <td>Canteen</td>
-                </tr>
-                <tr>
-                    <td>1:00 PM</td>
-                    <td>Closing Ceremony</td>
-                    <td>Campfire</td>
-                </tr>
-                </table>
+                  <td>Team Formation</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>10:30 PM</td>
+                  <td><span class="trail-hightlight">[Venture Trail]</span> Turn a Hackathon Project into a VC-Funded Product</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>11:30 PM</td>
+                  <td><span class="trail-hightlight">[Design Trail]</span> Intro to Design and Branding Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr class="heading">
+                  <th colspan="3">
+                  <h4>Saturday, April 13th</h4>
+                  </th>
+              </tr>
+              <tr>
+                      <th>TIME</th>
+                      <th>EVENT</th>
+                      <th>LOCATION</th>
+              </tr>
+              <tr>
+                  <td>12:00 AM</td>
+                  <td>Insomnia Cookies</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>1:00 AM</td>
+                  <td>Smash Tournament</td>
+                  <td>Power Peak</td>
+              </tr>
+              <tr>
+                  <td>1:30 AM</td>
+                  <td>Lifesize Hungry Hungry Hippos</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>8:30 AM</td>
+                  <td>Breakfast</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>9:00 AM</td>
+                  <td>Attorney AMA</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>10:00 AM</td>
+                  <td>Amp Up Your Apps With Maps by Esri</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>11:00 AM</td>
+                  <td>Discover the Office 365 Developer Platform by Microsoft</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>11:30 AM</td>
+                  <td><span class="trail-hightlight">[Venture Trail]</span> Entrepeneurship Panel</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>12:00 PM</td>
+                  <td>Open-Source Intelligence Techniques Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>12:30 PM</td>
+                  <td>Lunch</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>1:00 PM</td>
+                  <td><span class="trail-hightlight">[Design Trail]</span> GIFs Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>2:00 PM</td>
+                  <td>Go Bananas Over UX by FINRA</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>2:00 PM</td>
+                  <td>Office Hours with 1517 Fund</td>
+                  <td>1517 Fund Booth</td>
+              </tr>
+              <tr>
+                  <td>2:30 PM</td>
+                  <td>Women in Tech Fireside Chat</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>3:00 PM</td>
+                  <td>Using Technology to Improve Healthcare by Credible Behaviorial Health</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>3:30 PM</td>
+                  <td><span class="trail-hightlight">[Design & Scout Trail]</span> Design Thinking Workshop</td>
+                  <td>Breakout Room</td>
+              </tr>
+              <tr>
+                  <td>4:00 PM</td>
+                  <td>COLORWAR</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>6:00 PM</td>
+                  <td><span class="trail-hightlight">[Venture Trail]</span> Venture Capital and the Art of Funding Your Startup w/ Mike Volpi</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>6:30 PM</td>
+                  <td>Dinner</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>7:00 PM</td>
+                  <td>How 2 Blink LEDs Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>7:30 PM</td>
+                  <td>The Coding Interview Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>8:00 PM</td>
+                  <td>Self-Driving Cars Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>8:00 PM</td>
+                  <td>Ballroom Dancing</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>9:00 PM</td>
+                  <td><span class="trail-hightlight">[Scout Trail]</span> Intro to Web Development Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>10:00 PM</td>
+                  <td>Insomnia Cookies</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>10:00 PM</td>
+                  <td>Intro to Crypto and Blockchain Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr>
+                  <td>11:00 PM</td>
+                  <td>SLAM: Why Robots Don&apos;t Crash Workshop</td>
+                  <td>Cabin</td>
+              </tr>
+              <tr class="heading">
+                  <th colspan="3">
+                  <h4>Sunday, April 14th</h4>
+                  </th>
+              </tr>
+              <tr>
+                      <th>TIME</th>
+                      <th>EVENT</th>
+                      <th>LOCATION</th>
+              </tr>
+              <tr>
+                  <td>12:00 AM</td>
+                  <td>S&apos;mores by APT</td>
+                  <td>Campfire II</td>
+              </tr>
+              <tr>
+                  <td>12:00 AM</td>
+                  <td>MLH Cup Stacking</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>1:00 AM</td>
+                  <td>Late Night Board Game Break</td>
+                  <td>Campfire</td>
+              </tr>
+              <tr>
+                  <td>8:00 AM</td>
+                  <td>Devpost Submission Deadline</td>
+                  <td>Campgrounds</td>
+              </tr>
+              <tr>
+                  <td>8:00 AM</td>
+                  <td>Breakfast</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>9:00 AM</td>
+                  <td>Hacking Ends</td>
+                  <td>Campgrounds</td>
+              </tr>
+              <tr>
+                  <td>9:30 AM</td>
+                  <td>Expo A</td>
+                  <td>Campgrounds</td>
+              </tr>
+              <tr>
+                  <td>11:00 AM</td>
+                  <td>Expo B</td>
+                  <td>Campgrounds</td>
+              </tr>
+              <tr>
+                  <td>12:00 PM</td>
+                  <td>Lunch</td>
+                  <td>Canteen</td>
+              </tr>
+              <tr>
+                  <td>1:00 PM</td>
+                  <td>Closing Ceremony</td>
+                  <td>Campfire</td>
+              </tr>
+              </table>
+            -->
             </div>
           </div>
         </div>
@@ -518,8 +520,7 @@ PM</td>
               </p>
               <h5>What is Devpost?</h5>
               <p>
-                After the 36 hours, you’ll be submitting your project to DevPost for judging!
-                New to Devpost? <a target="_blank" href="https://docs.google.com/presentation/d/1rLijx3npVBSLCfxYSGzmBF8Q6B_NQkkPMlmPhUM4BFQ/edit#slide=id.g2e3ac65a77_0_35">Here's</a> a quick introduction!
+                After the 36 hours, you’ll be submitting your project to DevPost for judging! New to Devpost? <a target="_blank" href="https://docs.google.com/presentation/d/1rLijx3npVBSLCfxYSGzmBF8Q6B_NQkkPMlmPhUM4BFQ/edit#slide=id.g2e3ac65a77_0_35">Here's</a> a quick introduction!
               </p>
               <h5>What hardware will be available at Bitcamp?</h5>
               <p>
@@ -530,7 +531,7 @@ PM</td>
             <div class="col-md-6">
               <h5>Timing</h5>
               <p>
-                Participants will arrive between 5PM and 8PM on Friday, April 12th, 2019. Our Sponsor Fair will also be at 7PM, where you can spend time going around and check out our different sponsor booths. Hacking starts Friday evening after opening ceremony. Closing ceremony will begin at 1PM on Sunday, April 14th, 2019.
+                Participants will arrive between 6PM and 8PM on Friday, April 12th, 2019. Our Sponsor Fair will also be at 7PM, where you can spend time going around and check out our different sponsor booths. Hacking starts Friday evening after opening ceremony. Closing ceremony will begin at 3PM on Sunday, April 14th, 2019. For a better idea of the flow of the event, check out our <a href="https://2018.bit.camp/" target="_blank">schedule</a> from Bitcamp 2018!
               </p>
               <h5>Location</h5>
               <p>
@@ -538,11 +539,11 @@ PM</td>
               </p>
               <h5>Travel</h5>
               <p>
-                We'll have buses covering the hike from Stony Brook, NYU, GWU, Georgetown, American, and UMBC. Information about securing your spot on these buses will be sent out soon! Travel reimbursement applications have closed for this year.
+                We'll have buses covering the hike from many colleges. If there are many registered campers from one specific college, we will try to have a bus for it. We will be reimbursing any individual’s hiking expenses on a case-by-case basis. Please contact travel@bit.camp for more information.
               </p>
               <h5>Packing List</h5>
               <p>
-                Bring yourself, a photo ID, your signed waiver (if applicable), a change of clothes, toiletries, a towel, a sleeping bag/blanket, your hacker setup (laptop, charger, headphones, tablet for designers), and maybe an idea or two!
+                Bring yourself, a photo ID, your signed waiver (if applicable), a change of clothes, toiletries, a sleeping bag/blanket, your hacker setup (laptop, charger, headphones, tablet for designers), and maybe an idea or two!
               </p>
               <h5>Teams</h5>
               <p>
@@ -553,7 +554,7 @@ PM</td>
                 Don't bring any firearms, knives, weapons, drugs, or alcohol. Don't use an old project. Start a new trail instead! Also, please read the <a target="_blank"  href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf">Major League Hacking Code of Conduct</a> and the <a target="_blank" href="./terms-code-waiver.pdf">Bitcamp Terms, Code of Conduct, and Release Waiver</a>. Organizers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensure a safe environment for everybody (TL;DR be nice).
               </p>
               <h5>Other questions?</h5>
-              <p>Send us an email at <a href="mailto:hello@bit.camp">hello@bit.camp</a> or message us on <a target="_blank" href="https://www.facebook.com/bitcmp">Facebook</a>!</p>
+              <p>Please send some mail to <a href="mailto:hello@bit.camp">hello@bit.camp</a>!</p>
           </div>
         </div>
       </article>
@@ -874,16 +875,13 @@ PM</td>
       <article class="footer dark">
         <div class="container">
           <div class="text-center">
-            <h2>Feel free to <a href="mailto:hello@bit.camp">email</a> us or find us on:</h2>
+            <h2>Send us mail at <a href="mailto:hello@bit.camp">hello@bit.camp</a> or tweet <a target="_blank" href="https://twitter.com/bitcmp">@bitcmp</a></h2>
             <div class="social-icons">
               <a target="_blank" href="https://www.facebook.com/bitcmp">
                 <img class="icon" src="img/social/face.png" alt="">
               </a>
               <a target="_blank" href="https://instagram.com/bitcamp">
                 <img class="icon" src="img/social/insta.png" alt="">
-              </a>
-              <a target="_blank" href="https://www.youtube.com/channel/UC_F_7Hv3SAUcQBubYWD-2BA">
-                <img class="icon" src="img/social/youtube.png" alt="">
               </a>
               <a target="_blank" href="https://twitter.com/bitcmp">
                 <img class="icon" src="img/social/twit.png" alt="">

--- a/index.html
+++ b/index.html
@@ -121,9 +121,6 @@
       <div class="separator dark-sky"></div>
       <article class="trails medium" id="trails">
         <div class="container">
-          <svg class="first trail" viewBox="-30 0 260 100" width="100%" height="16rem" preserveAspectRatio="none">
-            <path class="trail_path" d="M0.5,0.7c2.3,57.9 15.2,62.7 30.5,55.4S82.2-60.5,99.3,98.8"></path>
-          </svg>
           <div class="text-center">
             <h2>Explore Our New Trails</h2>
             <h3>
@@ -166,9 +163,6 @@
       <div class="separator light-sky"></div>
 
       <article id="colorwar" class="colorwar dark">
-        <svg class="trail" viewBox="20 -20 736.8 138.9" width="100%" height="35rem" preserveAspectRatio="none" style="top:-30rem">
-            <path class="trail_path" d="M528,0.7C517,38,474,64,415,64c-66,0-135,33-113,54.9"></path>
-          </svg>
         <div class="container text-center">
           <div class="row">
             <div class="col-md-8 offset-md-2">
@@ -187,9 +181,6 @@
       </article>
 
       <article class="schedule medium" id="schedule">
-        <svg class="first trail" viewBox="200 0 100 250" width="100%" height="35rem" preserveAspectRatio="true">
-            <path class="trail_path" d="M200,20 C226.541174,99.3274992 277.89966,130.638413 314.075456,113.932741 C368.33915,88.8742329 298.364814,13.3634242 265.845703,70.2070312 C233.326592,227.050638 112.512695,309.21582 243.4355469,2628.853516"></path>
-          </svg>
         <div class="container text-center">
           <div class="row">
             <div class="col-lg-10 offset-lg-1 col-md-12 col-12">
@@ -490,9 +481,6 @@ PM</td>
 
       <article class="faq dark" id="faq">
         <div class="container">
-          <svg class="trail" viewBox="0 0 736.8 138.9" width="100%" height="24rem" preserveAspectRatio="none" style="top:-30rem">
-            <path class="trail_path" d="M528,0.7C517,38,474,64,415,64c-66,0-135,33-113,74.9"/>
-          </svg>
           <div class="text-center">
             <h2>FAQ</h2>
           </div>
@@ -575,9 +563,6 @@ PM</td>
 
       <article class="sponsors medium" id="sponsors">
         <div class="container">
-          <svg class="first trail" viewBox="-30 0 260 100" width="100%" height="16rem" preserveAspectRatio="none">
-            <path class="trail_path" d="M0.5,0.7c2.3,57.9 15.2,62.7 30.5,55.4S82.2-60.5,99.3,98.8"></path>
-          </svg>
           <div class="text-center">
             <h2>Sponsors</h2>
             <div class="pitch">
@@ -888,9 +873,6 @@ PM</td>
 
       <article class="footer dark">
         <div class="container">
-          <svg class="trail" viewBox="-180 0 500 100" width="100%" height="24rem" preserveAspectRatio="none" style="top:-30rem">
-            <path class="trail_path" d="M75.6,0c27,50-111,45.6-95.6,100"/""></path>
-          </svg>
           <div class="text-center">
             <h2>Feel free to <a href="mailto:hello@bit.camp">email</a> us or find us on:</h2>
             <div class="social-icons">

--- a/index.html
+++ b/index.html
@@ -1011,6 +1011,9 @@ PM</td>
             <a target="_blank" href="https://instagram.com/bitcamp">
               <img class="icon" src="img/social/insta.png" alt="">
             </a>
+            <a target="_blank" href="https://www.youtube.com/channel/UC_F_7Hv3SAUcQBubYWD-2BA">
+              <img class="icon" src="img/social/youtube.png" alt="">
+            </a>
             <a target="_blank" href="https://twitter.com/bitcmp">
               <img class="icon" src="img/social/twit.png" alt="">
             </a>

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -243,6 +243,22 @@ article.intro {
   }
 }
 
+article.trails {
+  @extend .page-section;
+  .col-content {
+    @media (max-width: 767.98px) {
+      text-align: center;
+    }
+    margin-top: 4rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    .icon {
+      margin-top: 4rem;
+      margin-bottom: 2rem;
+    }
+  }
+}
+
 article.colorwar {
   @extend .page-section;
   background-image: url('../img/colorwarbg.jpg');
@@ -379,8 +395,4 @@ div.separator {
     background-color: $bp-midnight-blue-light;
     background-image: url('../img/testx2.jpg');
   }
-}
-
-.container {
-  position: relative;
 }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -187,61 +187,6 @@ article.hero {
 .page-section {
   position: relative;
   padding: 12rem 0rem;
-  .trail {
-    position: absolute;
-    z-index: 99;
-    top: -22rem;
-    // width: 50rem;
-    //max-width: 36%;
-    // height: 10rem;
-    &.left {
-      -webkit-transform: rotate(-10deg);
-      transform: rotate(-10deg);
-      right: 50%;
-      &.flipped {
-        -webkit-transform: scaleX(-1) rotate(-10deg);
-        transform: scaleX(-1) rotate(-10deg);
-      }
-    }
-    &.right {
-      -webkit-transform: rotate(-12deg);
-      transform: rotate(-12deg);
-      left: 50%;
-      &.flipped {
-        -webkit-transform: scaleY(-1) rotate(-12deg);
-        transform: scaleY(-1) rotate(-12deg);
-      }
-    }
-  }
-  @media (max-width: 767.98px) {
-    .first.trail {
-      left: 14%;
-    }
-    .trail {
-      position: absolute;
-      z-index: 99;
-      top: -22rem;
-      //max-width: 36%;
-      &.left {
-        -webkit-transform: scaleX(2) scaleY(2) rotate(-20deg);
-        transform: rotate(-20deg) scaleX(2) scaleY(2);
-        right: 30%;
-        &.flipped {
-          -webkit-transform: scaleX(-2) scaleY(2) rotate(-20deg);
-          transform: scaleX(-2) scaleY(2) rotate(-20deg);
-        }
-      }
-      &.right {
-        -webkit-transform: scaleY(-2) scaleX(2) rotate(-22deg);
-        transform: scaleY(-2) scaleX(2) rotate(-22deg);
-        left: 30%;
-        &.flipped {
-          -webkit-transform: scaleX(2) scaleY(2) rotate(-22deg);
-          transform: rotate(-22deg) scaleX(2) scaleY(2);
-        }
-      }
-    }
-  }
   h2 {
     font-size: 2.4rem;
     margin-bottom: 2rem;
@@ -294,22 +239,6 @@ article.intro {
     image-rendering: pixelated;
     @media (max-width: 767.98px) {
       margin-top: 8rem;
-    }
-  }
-}
-
-article.trails {
-  @extend .page-section;
-  .col-content {
-    @media (max-width: 767.98px) {
-      text-align: center;
-    }
-    margin-top: 4rem;
-    padding-left: 2rem;
-    padding-right: 2rem;
-    .icon {
-      margin-top: 4rem;
-      margin-bottom: 2rem;
     }
   }
 }
@@ -450,26 +379,6 @@ div.separator {
     background-color: $bp-midnight-blue-light;
     background-image: url('../img/testx2.jpg');
   }
-}
-
-.trail_visible .trail_path {
-  stroke-dashoffset: 0;
-}
-
-.trail_path{
-  fill:none;
-  stroke:#CDECF9;
-  stroke-width:7;
-  vector-effect: non-scaling-stroke;
-  stroke-dasharray:21.706,14.706,21.706,14.706,21.706,14.706,
-                   21.706,14.706,21.706,14.706,21.706,14.706,
-                   21.706,14.706,21.706,14.706,21.706,14.706,
-                   21.706,14.706,21.706,14.706,21.706,14.706,
-                   21.706,14.706,21.706,14.706,21.706,14.706,
-                   21.706,14.706,21.706,14.706,21.706,14.706,
-                   0,100000;
-  stroke-dashoffset: 655.416;
-  transition: 2s;
 }
 
 .container {


### PR DESCRIPTION
This branch removes most of the 2018-specific markup from website. Some of the text was updated with information from [this powerpoint](https://docs.google.com/presentation/d/1BsP9QkNL9FSJuObThAveLSw0LABHpFy17Wr38EWmqq4/edit#slide=id.g2fa7d26b9b_0_98). All of the trails were removed, both from the html and the scss. 